### PR TITLE
fix: link liblog on Android + skip blank logcat/os_log rows (1.3.1)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.3.0 LANGUAGES C)
+project(dart_bridge VERSION 1.3.1 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)
@@ -112,6 +112,16 @@ if(ANDROID)
   set_target_properties(dart_bridge PROPERTIES
     LINK_FLAGS "-Wl,-z,max-page-size=16384"
   )
+  # `__android_log_write` lives in liblog.so. dart_bridge.c uses it for
+  # the native sys.stdout/sys.stderr → logcat redirect installed at
+  # Py_Initialize. Without an explicit link, this symbol resolves
+  # transitively through libpython3.so on newer Python builds (3.13+)
+  # but NOT on 3.12, which surfaces as
+  #   dlopen failed: cannot locate symbol "__android_log_write"
+  # at app start. Make the dependency explicit so libdart_bridge has
+  # liblog in its own DT_NEEDED regardless of which Python it's paired
+  # with.
+  target_link_libraries(dart_bridge PRIVATE log)
 endif()
 
 if(UNIX AND NOT APPLE AND NOT ANDROID)

--- a/src/dart_bridge.c
+++ b/src/dart_bridge.c
@@ -239,9 +239,27 @@ EXPORT void dart_bridge_signal_dart_session(int n_pairs,
 // fwrite per platform.
 // ---------------------------------------------------------------------------
 
+// Returns 1 if every byte in `buf` is whitespace (space/tab/CR/LF), 0
+// otherwise. Used to drop the standalone "\n" writes that CPython's
+// `print(x)` emits separately after the value — otherwise each print()
+// produces a blank logcat / os_log entry alongside its real line.
+static int is_all_whitespace(const char* buf, Py_ssize_t len) {
+    for (Py_ssize_t i = 0; i < len; i++) {
+        char c = buf[i];
+        if (c != ' ' && c != '\t' && c != '\n' && c != '\r') return 0;
+    }
+    return 1;
+}
+
 static void native_log_write(int is_stderr, const char* buf, Py_ssize_t len) {
     if (len <= 0) return;
 #if defined(__ANDROID__)
+    // __android_log_write adds its own newline per call AND every entry
+    // has a row of metadata. Standalone "\n" writes from `print()`'s
+    // second sub-call would each become a blank logcat row — skip them.
+    // (Multi-byte whitespace runs e.g. "\n\n" coalesce to one skipped
+    // call, which is also what the user wants visually.)
+    if (is_all_whitespace(buf, len)) return;
     // __android_log_write expects a NUL-terminated string. Buffer is
     // typically short (one write call per print line); copy + NUL-pad.
     char stack_buf[1024];
@@ -259,6 +277,9 @@ static void native_log_write(int is_stderr, const char* buf, Py_ssize_t len) {
                         "flet.python", tmp);
     if (tmp != stack_buf) free(tmp);
 #elif defined(__APPLE__)
+    // os_log behaves like logcat — one entry per call with its own
+    // metadata. Same blank-line skip applies.
+    if (is_all_whitespace(buf, len)) return;
     // os_log truncates at ~1KB by default; for longer payloads we'd want
     // to chunk. Most print()s are well under that. is_stderr maps to
     // OS_LOG_TYPE_ERROR, otherwise OS_LOG_TYPE_DEFAULT.
@@ -278,8 +299,10 @@ static void native_log_write(int is_stderr, const char* buf, Py_ssize_t len) {
     }
     if (tmp != stack_buf) free(tmp);
 #else
-    // Desktop: fd 1/2 work — passthrough preserves existing behavior so
-    // `flet run` console output, CI logs, etc. keep flowing.
+    // Desktop: keep raw passthrough — fd 1/2 go to a real terminal and
+    // newlines need to land so consecutive prints stay on separate
+    // lines. No whitespace skip. `flet run` console output, CI logs,
+    // etc. keep flowing exactly as before.
     fwrite(buf, 1, (size_t)len, is_stderr ? stderr : stdout);
     if (is_stderr) fflush(stderr);
 #endif


### PR DESCRIPTION
## Summary

Two bug fixes layered on the 1.3.0 native-log-redirect work:

### 1. liblog linkage on Android

`dart_bridge.c` calls `__android_log_write` for the native `sys.stdout` / `sys.stderr` redirect installed at `Py_Initialize`. The symbol lives in Android's `liblog.so`, but CMakeLists.txt didn't link against it explicitly.

This surfaced **asymmetrically across Python versions** in serious-python's CI:

* Python **3.13 / 3.14**: `libpython3.X.so` itself transitively `DT_NEEDED`s `liblog.so` (newer libpython builds with their own logging), so `__android_log_write` resolves via that chain at dlopen.
* Python **3.12**: libpython doesn't pull in liblog. App start fails with:

  ```
  dlopen failed: cannot locate symbol "__android_log_write" referenced by
  "/data/app/.../com.flet.serious_python_bridge_example-.../lib/x86_64/libdart_bridge.so"
  ```

  ([failing run](https://github.com/flet-dev/serious-python/actions/runs/27641369358/job/81741962590)).

Fix: explicit `target_link_libraries(dart_bridge PRIVATE log)` inside the ANDROID block so libdart_bridge has its own `DT_NEEDED liblog.so` and works against every libpython we ship.

### 2. Blank logcat / os_log rows from `print()`

CPython's `print(x)` is internally two writes: `write(x)` followed by `write("\n")`. After the trailing-newline strip in `native_log_write`, the standalone `"\n"` write becomes an empty string but we still called `__android_log_write` / `os_log_with_type` with it — producing a blank row after every real log line:

\`\`\`
I  flet.python  Hello, Flet!
I  flet.python
I  flet.python  Another line of output.
I  flet.python
\`\`\`

Add `is_all_whitespace` and short-circuit inside the Android and iOS branches. Desktop passthrough keeps the raw `fwrite` because fd 1/2 go to a real terminal and need the `\n` to actually line-break the output (so `flet run` console flow is unchanged).

Result: one logcat / os_log entry per Python logical print line.

## Test plan

- [x] Local desktop build (macOS): cmake + link clean, dylib exports unchanged from 1.3.0.
- [ ] CI matrix build (Linux / Windows / Android × all Py versions / Apple xcframework).
- [ ] After tag + serious-python bump: re-run the Android Py 3.12 bridge_example tests that failed with the unresolved symbol — they should pass.
- [ ] flet build apk: `print("Hello")` should produce **one** `flet.python` logcat row, no trailing blank.