### PR TITLE
fix(ci): -llog in Android cross-compile + bump 1.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,6 +201,7 @@ jobs:
             -L "$LIBPYTHON_DIR" \
             "$LIBPYTHON" \
             -ldl \
+            -llog \
             -Wl,-z,max-page-size=16384 \
             -o "$OUT"
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.3.1 LANGUAGES C)
+project(dart_bridge VERSION 1.3.2 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)


### PR DESCRIPTION
## Why this is a separate PR

1.3.1 was supposed to fix \`__android_log_write\` unresolved on Android Py 3.12 by adding \`target_link_libraries(dart_bridge PRIVATE log)\` to CMakeLists.txt. But the **Android binaries in CI aren't built with CMake** — they go through a hand-rolled \`clang -shared\` invocation directly in \`.github/workflows/ci.yml\`. The CMake change has no effect on the shipped Android artifact, so 1.3.1's published \`libdart_bridge-android-*-py3.12.so\` was effectively the same as 1.3.0 — still missing \`liblog.so\` in \`DT_NEEDED\`, still crashing serious-python's Android Py 3.12 CI:

\`\`\`
$ strings libdart_bridge-android-x86_64-py3.12.so | grep '^lib.*\.so'
libc.so
libpython3.12.so
libdl.so       ← liblog.so missing
\`\`\`

## Fix

Add \`-llog\` to the clang link line in the \`build-android\` job. Trivial CI workflow change.

Keeping the CMakeLists.txt \`target_link_libraries(... PRIVATE log)\` from 1.3.1 too — semantically correct, so if anyone ever switches Android to CMake the link will Just Work. Currently dead code on Android, applied only if the platform's \`ANDROID\` CMake variable trips elsewhere.

Bump to 1.3.2 because the published Android binary needs to be re-released. Linux/Windows/Apple binaries are content-identical to 1.3.1 but get a new tag for consistency.

## Test plan

- [ ] CI build of this PR's Android matrix: \`llvm-readelf -d\` step (the diagnostic already in the job) should show \`liblog.so\` in NEEDED.
- [ ] After tag + serious-python bump: Android Py 3.12 bridge_example test should finally pass.