### PR TITLE
Android: install native-module finder before `site` (full API / PyConfig)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,6 @@ jobs:
 
           $CC -shared -fPIC -fvisibility=hidden \
             -DDART_SHARED_LIB \
-            -DPy_LIMITED_API=0x030c0000 \
             -I "$INCLUDE_DIR" \
             -I src \
             src/dart_bridge.c src/serious_python_run.c src/dart_api/dart_api_dl.c \

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,8 @@ __pycache__/
 
 # Misc
 .cache/
+
+# local cross-compile artifacts
+pydist_local/
+dist_local/
+/tmp/pamf.tar.gz

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.3.2 LANGUAGES C)
+project(dart_bridge VERSION 1.4.0 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -12,7 +12,13 @@
 // for sys.path / sys.argv adjustments.
 
 #define PY_SSIZE_T_CLEAN
+// Android uses the FULL CPython API (not abi3): it needs PyConfig to start the
+// interpreter with site disabled so the serious_python native-module finder is
+// installed before `site` runs. The Android binary is already per-CPython-version
+// (DT_NEEDED libpython3.X.so), so giving up abi3 portability there costs nothing.
+#if !defined(__ANDROID__)
 #define Py_LIMITED_API 0x030c0000
+#endif
 #include <Python.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -422,12 +428,31 @@ static int sp_run_python(sp_state_t* st) {
         return 1;
     }
 
+#ifdef __ANDROID__
+    // Start with site disabled so the serious_python native-module finder is
+    // installed BEFORE `site` runs (some lib-dynload extension modules could
+    // otherwise be imported during site, before the finder exists). PYTHONHOME /
+    // PYTHONPATH (applied via sp_apply_env above) are honoured by PyConfig, so the
+    // stdlib zip is on sys.path and `_sp_bootstrap` is importable here.
+    {
+        PyConfig config;
+        PyConfig_InitPythonConfig(&config);
+        config.site_import = 0;
+        PyStatus status = Py_InitializeFromConfig(&config);
+        PyConfig_Clear(&config);
+        if (PyStatus_Exception(status)) {
+            fprintf(stderr, "[serious_python_run] Py_InitializeFromConfig failed\n");
+            return 1;
+        }
+    }
+#else
     Py_Initialize();
 
     if (!Py_IsInitialized()) {
         fprintf(stderr, "[serious_python_run] Py_Initialize failed\n");
         return 1;
     }
+#endif
 
     // Install Python-level sys.stdout / sys.stderr wrappers that forward
     // to the platform's native log sink (logcat on Android, os_log on
@@ -436,6 +461,17 @@ static int sp_run_python(sp_state_t* st) {
     // setup, the user's module top-level statements) land in logcat
     // rather than vanishing into /dev/null on mobile.
     dart_bridge_install_stdio_redirect();
+
+#ifdef __ANDROID__
+    // Install the jniLibs native-module finder, THEN run site (which we disabled
+    // at init). The finder resolves CPython extension modules relocated into
+    // jniLibs/<abi>/ from their .soref markers in the stdlib/sitepackages zips.
+    if (sp_pyrun_string("import _sp_bootstrap; _sp_bootstrap.install()", "<sp_finder>") != 0
+        || sp_pyrun_string("import site; site.main()", "<sp_site>") != 0) {
+        Py_Finalize();
+        return 1;
+    }
+#endif
 
     if (sp_apply_program_name(st) != 0 || sp_apply_module_paths(st) != 0) {
         Py_Finalize();


### PR DESCRIPTION
## What

On **Android**, drop `Py_LIMITED_API` and start the interpreter via `PyConfig` with
`site_import = 0`, then run a fixed bootstrap — `import _sp_bootstrap; _sp_bootstrap.install()`
followed by `site.main()` — so a serious_python `sys.meta_path` finder is installed **before
`site` runs**. Other platforms (Apple/Linux/Windows) keep the abi3 / Limited-API path unchanged.

Bumps version to **1.4.0**.

## Why

This unblocks a new serious_python_android packaging design (in `serious_python`'s
`android-native-mmap` branch): CPython extension modules are relocated into `jniLibs/<abi>/`
and loaded **mmap'd directly from the APK** (no `useLegacyPackaging`, zero extraction), while
pure Python ships in stored asset zips read via `zipimport`. A custom finder resolves the
relocated natives from `.soref` markers — and it **must be installed before `site`**, because
a stdlib `lib-dynload` extension could otherwise be imported during `site` before the finder
exists. The Limited API has no hook to install it that early; `PyConfig` does.

Giving up abi3 on Android costs nothing: the Android binary is **already per-CPython-version**
(`DT_NEEDED` is `libpython3.X.so` via the python-build linker script), so it's published per
`(abi × python_version)` regardless.

## How it's guarded

- `#if !defined(__ANDROID__)` around `#define Py_LIMITED_API` — only Android gets the full API.
- The new init path is `#ifdef __ANDROID__`; the existing `Py_Initialize()` path is untouched
  elsewhere.
- The CI Android job already compiles per-version; it just stops passing `-DPy_LIMITED_API`
  for Android (follow-up — current CI still sets it, so this PR's binary is validated via a
  local cross-compile; see Testing).

## Testing

Cross-compiled locally with the NDK (`aarch64-linux-android21-clang`, `python-android-mobile-forge`
3.14 headers + `libpython3.14.so`) and verified on an arm64 emulator via the consuming
`serious_python` branch:

- App runs fully (bz2, sqlite, **numpy**) with the finder installed **solely by this shim**
  (interim `sitecustomize` removed) — proving the pre-`site` install works standalone.
- A bootstrap audit confirms **no extension module loads during core-init** before the finder
  (PyConfig core-init pulls only builtin/frozen modules).
- Natives are mmap'd from the APK (`/proc/<pid>/maps` shows `r-xp` segments backed by `base.apk`),
  zero extraction to app storage.

## Follow-up (not in this PR)

Done in this PR: CI Android job no longer passes -DPy_LIMITED_API, so the released v1.4.0 binaries are built with the full API/PyConfig.