### PR TITLE
Build armeabi-v7a for Python 3.13/3.14 (v1.4.1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -141,15 +141,16 @@ jobs:
         # substitutes -lpython3.X at link time, so DT_NEEDED in the resulting
         # libdart_bridge.so is the version-specific libpython3.X.so. That
         # makes Android binaries inherently tied to one CPython version —
-        # honest about that here with a matrix axis.
+        # honest about that here with a matrix axis. python-build publishes
+        # armeabi-v7a for every supported minor, so all ABIs build for all
+        # versions.
         abi: [arm64-v8a, armeabi-v7a, x86_64]
         python_version: ['3.12', '3.13', '3.14']
-        exclude:
-          # 32-bit Android dropped in CPython 3.13+ (PEP 738).
-          - abi: armeabi-v7a
-            python_version: '3.13'
-          - abi: armeabi-v7a
-            python_version: '3.14'
+    env:
+      # python-build release the Android Python headers/libpython come from.
+      # Keep in sync with serious_python's `pythonReleaseDate` — both link
+      # these binaries against the same date-keyed CPython artifacts.
+      PYTHON_BUILD_RELEASE_DATE: '20260629'
     steps:
       - uses: actions/checkout@v6
 
@@ -157,8 +158,16 @@ jobs:
         run: |
           set -euo pipefail
           VER=${{ matrix.python_version }}
+          DATE="$PYTHON_BUILD_RELEASE_DATE"
+          # Resolve the full CPython version for this minor from the pinned
+          # date-keyed release's manifest (the single source of truth shared
+          # with serious_python / flet), then pull that release's
+          # mobile-forge artifact — which carries armeabi-v7a for every minor.
+          curl -fL -o manifest.json \
+            "https://github.com/flet-dev/python-build/releases/download/${DATE}/manifest.json"
+          FULLVER=$(python3 -c "import json;print(json.load(open('manifest.json'))['pythons']['${VER}']['full_version'])")
           curl -fL -o pamf.tar.gz \
-            "https://github.com/flet-dev/python-build/releases/download/v${VER}/python-android-mobile-forge-${VER}.tar.gz"
+            "https://github.com/flet-dev/python-build/releases/download/${DATE}/python-android-mobile-forge-${FULLVER}.tar.gz"
           mkdir -p pydist
           # libpython3.so is the GNU linker script `INPUT(-lpython3.X)`;
           # extracting both lets ld follow the script to libpython3.X.so on
@@ -280,6 +289,8 @@ jobs:
             dist/libdart_bridge-android-arm64-v8a-py3.13.so
             dist/libdart_bridge-android-arm64-v8a-py3.14.so
             dist/libdart_bridge-android-armeabi-v7a-py3.12.so
+            dist/libdart_bridge-android-armeabi-v7a-py3.13.so
+            dist/libdart_bridge-android-armeabi-v7a-py3.14.so
             dist/libdart_bridge-android-x86_64-py3.12.so
             dist/libdart_bridge-android-x86_64-py3.13.so
             dist/libdart_bridge-android-x86_64-py3.14.so

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.4.0 LANGUAGES C)
+project(dart_bridge VERSION 1.4.1 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ standalone ships `libpython3.so` as a GNU linker script that resolves to
 `libpython3.<ver>.so`, so the resulting `DT_NEEDED` entry is version-
 specific and we publish a binary per `(abi × python_version)`.
 
-armeabi-v7a is only published for Python 3.12 — CPython dropped 32-bit
-Android in 3.13+ (PEP 738).
+armeabi-v7a (32-bit ARM) is published for every supported Python minor
+(3.12, 3.13, 3.14), matching python-build's per-minor `android_abis`.
 
 Download URL pattern:
 


### PR DESCRIPTION
## What

python-build now publishes `armeabi-v7a` (32-bit ARM) CPython distributions for **every** supported minor (3.12, 3.13, 3.14), not just 3.12. This builds and ships the matching dart_bridge binaries so downstream `serious_python` 4.2.0 / flet builds that target 32-bit ARM on 3.13/3.14 can resolve `libdart_bridge-android-armeabi-v7a-py{3.13,3.14}.so`.

Without this, `serious_python_android`'s `downloadDartBridge_armeabi-v7a` task 404s for 3.13/3.14.

## Changes

- **Drop the matrix excludes** for `armeabi-v7a × {3.13, 3.14}` — all ABIs now build for all supported minors.
- **Source the Android Python headers/libpython from the pinned date-keyed python-build release** (`PYTHON_BUILD_RELEASE_DATE=20260629`, full version resolved from that release's `manifest.json`) instead of the per-minor `v<minor>` tag. This is the single source of truth shared with serious_python / flet, and it carries `armeabi-v7a` for every minor.
- **Add the two new release assets**: `libdart_bridge-android-armeabi-v7a-py3.13.so`, `libdart_bridge-android-armeabi-v7a-py3.14.so`.
- **README**: armeabi-v7a is published for all supported minors.
- **Bump to 1.4.1.**

## Release

Tag **`v1.4.1`** after merge so CI publishes the Android binaries (incl. the new armeabi-v7a 3.13/3.14). python-build's `manifest.json` `dart_bridge_version` bumps to 1.4.1 in a companion PR; serious_python then regenerates to pin 1.4.1.