### PR TITLE
Multiprocessing child interception: run the host binary as a headless interpreter for spawn/forkserver/resource-tracker re-execs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,23 +20,60 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # Oldest supported GitHub runners on purpose: the .so is linked
-          # directly into end users' app executables, so the glibc it binds
-          # (e.g. __isoc23_strtoll@GLIBC_2.38 when built on 24.04) sets the
-          # minimum OS the app can BUILD AND RUN on. (22.04 = glibc 2.35)
-          - runner: ubuntu-22.04
+          - runner: ubuntu-24.04
             arch: x86_64
-          - runner: ubuntu-22.04-arm
+            cmake_arch: linux-x86_64
+          - runner: ubuntu-24.04-arm
             arch: aarch64
+            cmake_arch: linux-aarch64
     runs-on: ${{ matrix.runner }}
+    # Built inside the oldest distro flet supports — debian:10, glibc 2.28, matching
+    # the lowest tier of flet's client build matrix (manylinux_2_28). The .so is linked
+    # directly into end users' app executables at `flet build linux` time, so the glibc
+    # it binds sets the floor for every machine that builds or runs a flet Linux app.
+    # Building straight on a modern runner would raise that floor (e.g. glibc >= 2.38
+    # binds __isoc23_* symbol versions and breaks Ubuntu 22.04 LTS; even glibc 2.35
+    # binds pthread_create@GLIBC_2.34). A 2.28 floor covers Debian 10/11/12,
+    # Ubuntu 20.04/22.04/24.04, and RHEL 8+ with a single artifact per arch.
+    container:
+      image: debian:10
     steps:
+      # Debian 10 (buster) is EOL: its packages moved off the regular mirrors
+      # to archive.debian.org, and the archived Release files' validity dates
+      # have expired (hence Check-Valid-Until off). git + ca-certificates must
+      # be installed before actions/checkout — the action runs inside this
+      # container and needs them.
+      - name: Point apt at the Debian 10 archive (EOL distro)
+        run: |
+          printf '%s\n' \
+            'deb http://archive.debian.org/debian buster main' \
+            'deb http://archive.debian.org/debian buster-updates main' \
+            'deb http://archive.debian.org/debian-security buster/updates main' \
+            > /etc/apt/sources.list
+          echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+          apt-get update
+          apt-get install -y build-essential curl ca-certificates git unzip
+
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
-      - name: Install build deps
-        run: sudo apt-get update && sudo apt-get install -y cmake build-essential python3-dev
+      # Debian 10's apt ships CMake 3.13 — below dart-bridge's `cmake_minimum_required(3.15)`
+      # (and the local-dev fallback `find_package(Python3 COMPONENTS Development.Module)`
+      # path needs 3.18+). Kitware's official binary tarballs are built against old
+      # glibc, so a current CMake runs fine on buster.
+      - name: Install modern CMake
+        run: |
+          set -euo pipefail
+          CMAKE_VER=3.31.6
+          curl -fL -o cmake.tar.gz \
+            "https://github.com/Kitware/CMake/releases/download/v${CMAKE_VER}/cmake-${CMAKE_VER}-${{ matrix.cmake_arch }}.tar.gz"
+          tar -xzf cmake.tar.gz -C /opt
+          echo "/opt/cmake-${CMAKE_VER}-${{ matrix.cmake_arch }}/bin" >> "$GITHUB_PATH"
 
+      # We don't bundle Python — we only need Python.h and the abi3 stub
+      # libpython3.so to link against, so the artifact's DT_NEEDED stays
+      # version-agnostic (one binary for every CPython 3.12+).
       - name: Download python-linux-dart for abi3 link target
         run: |
           set -euo pipefail
@@ -47,6 +84,8 @@ jobs:
           echo "DART_BRIDGE_PYTHON_INCLUDE_DIRS=$PWD/pydist/include/python${PYVER}" >> "$GITHUB_ENV"
           echo "DART_BRIDGE_PYTHON_LIBRARIES=$PWD/pydist/lib/libpython3.so" >> "$GITHUB_ENV"
 
+      # Plain Release build; the two -D vars point CMake at the headers and
+      # stub downloaded above (skipping the local-dev find_package fallback).
       - name: Configure + build
         run: |
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
@@ -54,6 +93,10 @@ jobs:
             -DDART_BRIDGE_PYTHON_LIBRARIES="${DART_BRIDGE_PYTHON_LIBRARIES}"
           cmake --build build --parallel
 
+      # Dart hosts load this library to EMBED Python, so libpython must be in
+      # DT_NEEDED — unlike a Python extension module, where the interpreter
+      # already provides the symbols. Guards against the linking mistake
+      # where the .so builds fine but Py_Initialize crashes at dlopen time.
       - name: Verify DT_NEEDED includes libpython3.so
         run: |
           set -euo pipefail
@@ -62,6 +105,21 @@ jobs:
           echo "$NEEDED" | grep -q "libpython3.so" || \
             { echo "ERROR: libdart_bridge.so is missing libpython3.so in DT_NEEDED"; exit 1; }
 
+      # The real compatibility contract: the artifact must not reference any
+      # glibc symbol newer than 2.28 (flet's lowest supported tier). This is
+      # what a container bump would silently break — fail loudly instead.
+      - name: Verify glibc floor is at most 2.28
+        run: |
+          set -euo pipefail
+          MAX=$(objdump -T build/libdart_bridge.so | grep -oE 'GLIBC_2\.[0-9]+' | sort -V | tail -1)
+          echo "max versioned glibc symbol: ${MAX:-none}"
+          HIGHEST=$(printf '%s\nGLIBC_2.28\n' "${MAX:-GLIBC_2.0}" | sort -V | tail -1)
+          [ "$HIGHEST" = "GLIBC_2.28" ] || \
+            { echo "ERROR: artifact requires $MAX (> 2.28); build container is too new"; exit 1; }
+
+      # Arch-qualified filename: it's the exact name serious_python_linux's
+      # CMake downloads from releases, and it lets multi-arch artifacts
+      # coexist in caches and release pages.
       - name: Stage artifact with platform-tagged name
         run: |
           mkdir -p dist

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     strategy:
@@ -23,7 +26,9 @@ jobs:
             arch: aarch64
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Install build deps
         run: sudo apt-get update && sudo apt-get install -y cmake build-essential python3-dev
@@ -60,7 +65,7 @@ jobs:
           file dist/libdart_bridge-linux-${{ matrix.arch }}.so
           ls -lh dist/
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: libdart_bridge-linux-${{ matrix.arch }}
           path: dist/libdart_bridge-linux-${{ matrix.arch }}.so
@@ -75,7 +80,9 @@ jobs:
         # Debug CRT  = consumed by `flutter run` / Debug Flutter apps
         config: [release, debug]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download python-windows-for-dart (headers + abi3 stub libs)
         shell: pwsh
@@ -123,7 +130,7 @@ jobs:
           }
           Get-Item "$outDir\$outName" | Format-List FullName, Length
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dart_bridge-windows-x86_64-${{ matrix.config }}
           path: |
@@ -152,7 +159,9 @@ jobs:
       # these binaries against the same date-keyed CPython artifacts.
       PYTHON_BUILD_RELEASE_DATE: '20260629'
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download Python headers + libpython (python-android-mobile-forge)
         run: |
@@ -217,7 +226,7 @@ jobs:
           echo "DT_NEEDED entries (should include libpython${VER}.so):"
           $NDK/toolchains/llvm/prebuilt/linux-x86_64/bin/llvm-readelf -d "$OUT" | grep NEEDED || true
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: libdart_bridge-android-${{ matrix.abi }}-py${{ matrix.python_version }}
           path: dist/libdart_bridge-android-${{ matrix.abi }}-py${{ matrix.python_version }}.so
@@ -226,7 +235,9 @@ jobs:
   build-apple:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Download Python iOS dist (headers)
         run: |
@@ -247,7 +258,7 @@ jobs:
           ls -la dist/
           du -sh dist/dart_bridge-apple.xcframework.zip
 
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: dart_bridge-apple-xcframework
           path: dist/dart_bridge-apple.xcframework.zip
@@ -263,7 +274,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts
 
@@ -275,7 +286,7 @@ jobs:
           ls -lh dist/
 
       - name: Attach to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         with:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
       # be installed before actions/checkout — the action runs inside this
       # container and needs them.
       - name: Point apt at the Debian 10 archive (EOL distro)
+        shell: bash
         run: |
           printf '%s\n' \
             'deb http://archive.debian.org/debian buster main' \
@@ -52,7 +53,7 @@ jobs:
             > /etc/apt/sources.list
           echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
           apt-get update
-          apt-get install -y build-essential curl ca-certificates git unzip
+          apt-get install -y build-essential curl ca-certificates git unzip file
 
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -63,6 +64,7 @@ jobs:
       # path needs 3.18+). Kitware's official binary tarballs are built against old
       # glibc, so a current CMake runs fine on buster.
       - name: Install modern CMake
+        shell: bash
         run: |
           set -euo pipefail
           CMAKE_VER=3.31.6
@@ -75,6 +77,7 @@ jobs:
       # libpython3.so to link against, so the artifact's DT_NEEDED stays
       # version-agnostic (one binary for every CPython 3.12+).
       - name: Download python-linux-dart for abi3 link target
+        shell: bash
         run: |
           set -euo pipefail
           PYVER=3.12   # any 3.12+ works; we only need headers + abi3 stub libpython3.so
@@ -87,6 +90,7 @@ jobs:
       # Plain Release build; the two -D vars point CMake at the headers and
       # stub downloaded above (skipping the local-dev find_package fallback).
       - name: Configure + build
+        shell: bash
         run: |
           cmake -B build -S . -DCMAKE_BUILD_TYPE=Release \
             -DDART_BRIDGE_PYTHON_INCLUDE_DIRS="${DART_BRIDGE_PYTHON_INCLUDE_DIRS}" \
@@ -98,6 +102,7 @@ jobs:
       # already provides the symbols. Guards against the linking mistake
       # where the .so builds fine but Py_Initialize crashes at dlopen time.
       - name: Verify DT_NEEDED includes libpython3.so
+        shell: bash
         run: |
           set -euo pipefail
           NEEDED=$(readelf -d build/libdart_bridge.so | grep NEEDED || true)
@@ -109,6 +114,7 @@ jobs:
       # glibc symbol newer than 2.28 (flet's lowest supported tier). This is
       # what a container bump would silently break — fail loudly instead.
       - name: Verify glibc floor is at most 2.28
+        shell: bash
         run: |
           set -euo pipefail
           MAX=$(objdump -T build/libdart_bridge.so | grep -oE 'GLIBC_2\.[0-9]+' | sort -V | tail -1)
@@ -121,6 +127,7 @@ jobs:
       # CMake downloads from releases, and it lets multi-arch artifacts
       # coexist in caches and release pages.
       - name: Stage artifact with platform-tagged name
+        shell: bash
         run: |
           mkdir -p dist
           cp build/libdart_bridge.so dist/libdart_bridge-linux-${{ matrix.arch }}.so

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu-24.04
+          # Oldest supported GitHub runners on purpose: the .so is linked
+          # directly into end users' app executables, so the glibc it binds
+          # (e.g. __isoc23_strtoll@GLIBC_2.38 when built on 24.04) sets the
+          # minimum OS the app can BUILD AND RUN on. (22.04 = glibc 2.35)
+          - runner: ubuntu-22.04
             arch: x86_64
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: aarch64
     runs-on: ${{ matrix.runner }}
     steps:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: zizmor - GitHub Actions Security Analysis
+
+on:
+  push:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6
+        with:
+          # Fork PRs get a read-only token (no security-events: write), so the
+          # SARIF upload would fail. Skip it for forks — they still get inline
+          # annotations; pushes and same-repo PRs upload to code scanning.
+          advanced-security: ${{ github.event.pull_request.head.repo.fork != true }}

--- a/README.md
+++ b/README.md
@@ -28,8 +28,65 @@ bridge transparently.
   `serious_python_run(config)` (sync or async via Dart port),
   `serious_python_register_extension(name, init)` (additional inittab
   entries beyond dart_bridge), `serious_python_request_stop()`,
-  `serious_python_finalize()`.
+  `serious_python_finalize()`, and the multiprocessing child-interception
+  pair described below.
 - `src/dart_api/` — Dart SDK headers (vendored from the Dart SDK).
+
+## Multiprocessing child interception (1.5.0+)
+
+Python's `multiprocessing` module (`spawn`/`forkserver` start methods and the
+resource tracker) launches helper processes by re-executing `sys.executable`
+with CPython-generated command lines. In an app embedding Python through this
+library, `sys.executable` points at the **host executable**. Without
+interception, each worker re-launches the host app — typically a full GUI —
+instead of running the multiprocessing helper protocol
+([flet-dev/flet#4283](https://github.com/flet-dev/flet/issues/4283)).
+
+`dart_bridge` exports entry points that let the host binary act as a plain
+Python interpreter for exactly those helper invocations:
+
+```c
+int serious_python_is_mp_invocation(int argc, char** argv);
+int serious_python_main(int argc, char** argv);           // delegates to Py_BytesMain
+
+// Windows wide-char variants for wWinMain argv:
+int serious_python_is_mp_invocation_w(int argc, wchar_t** argv);
+int serious_python_main_w(int argc, wchar_t** argv);      // delegates to Py_Main
+```
+
+Host contract: call the detector as the **first thing** in `main`,
+`wWinMain`, or `main.swift`, before any UI, COM, Flutter, GTK, AppKit, or
+engine initialization:
+
+```c
+if (serious_python_is_mp_invocation(argc, argv)) {
+    return serious_python_main(argc, argv);
+}
+```
+
+`serious_python_is_mp_invocation` recognizes CPython multiprocessing helper
+commands by matching `--multiprocessing-fork` anywhere in `argv`, or a `-c`
+payload beginning with `from multiprocessing.` or
+`import sys; from multiprocessing.`. The match is intentionally prefix-based:
+these command lines are CPython implementation details and have changed across
+minor releases, while the helpers remain under `multiprocessing.*`.
+
+`serious_python_main` prepares the child process, scrubs `PYTHONINSPECT`,
+registers the in-binary `dart_bridge` module with the inittab, and delegates
+to the standard CPython command-line entry point. The child locates the
+embedded stdlib/site-packages through the `PYTHONHOME`/`PYTHONPATH`
+environment inherited from the parent process; `serious_python_run` sets those
+process-wide before initializing Python.
+
+On Windows, prefer the `_w` variants from `wWinMain` so Unicode argv values are
+passed directly to `Py_Main` instead of being decoded through the ANSI code
+page.
+
+On Apple platforms, exported entry points are also marked `used`: the
+`dart_bridge` archive is statically linked into the host app, and some public
+symbols are referenced only through `dlsym`/Dart FFI. The marker prevents the
+host linker's dead-strip pass from discarding exports that have no ordinary C
+call site.
 
 ## Released binaries
 

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -82,17 +82,24 @@ static int sp_pyrun_file(FILE *fp, const char *filename) {
 #if defined(_WIN32)
 #include <windows.h>
 #include <process.h>
+#include <wchar.h>
 #define EXPORT __declspec(dllexport)
 #define SP_PATH_SEP "\\"
 #define SP_PYPATH_SEP ";"
 static int sp_setenv(const char* k, const char* v) { return _putenv_s(k, v); }
+static int sp_unsetenv(const char* k) { return _putenv_s(k, ""); }
 #else
 #include <pthread.h>
 #include <unistd.h>
-#define EXPORT __attribute__((visibility("default")))
+// `used` is mainly for Darwin/Mach-O: dart_bridge is statically linked into
+// the host app, and some public entry points are discovered later via dlsym
+// / Dart FFI. Mark exported functions as used so the host linker's dead-strip
+// pass does not discard exports with no ordinary C call site.
+#define EXPORT __attribute__((visibility("default"), used))
 #define SP_PATH_SEP "/"
 #define SP_PYPATH_SEP ":"
 static int sp_setenv(const char* k, const char* v) { return setenv(k, v, 1); }
+static int sp_unsetenv(const char* k) { return unsetenv(k); }
 #endif
 
 // PyInit_dart_bridge lives in dart_bridge.c, linked into the same binary.
@@ -141,6 +148,14 @@ EXPORT int  serious_python_register_extension(const char* name, sp_pyinit_func_t
 EXPORT int  serious_python_run(const sp_run_config_t* cfg);
 EXPORT int  serious_python_request_stop(void);
 EXPORT void serious_python_finalize(void);
+EXPORT int  serious_python_is_mp_invocation(int argc, char** argv);
+EXPORT int  serious_python_main(int argc, char** argv);
+#if defined(_WIN32)
+// Wide-char variants for Windows hosts (wWinMain argv is wchar_t**; going
+// through the narrow versions would decode through the ANSI code page).
+EXPORT int  serious_python_is_mp_invocation_w(int argc, wchar_t** argv);
+EXPORT int  serious_python_main_w(int argc, wchar_t** argv);
+#endif
 
 // ---------------------------------------------------------------------------
 // Registered Python extensions (in addition to dart_bridge)
@@ -560,3 +575,129 @@ EXPORT void serious_python_finalize(void) {
         Py_Finalize();
     }
 }
+
+// ---------------------------------------------------------------------------
+// Multiprocessing child-process support
+//
+// Python's `multiprocessing` spawn/forkserver paths, plus the resource tracker,
+// launch helper processes by re-executing `sys.executable` with a CPython
+// command line. In serious_python-hosted apps, the launcher points
+// `sys.executable` at the host app binary, so those helpers would otherwise
+// start another GUI app instead of a headless Python interpreter.
+// See https://github.com/flet-dev/flet/issues/4283.
+//
+// The host runner should call `serious_python_is_mp_invocation` before any
+// UI/engine initialization. If it returns non-zero, the runner should exit with
+// `serious_python_main(argc, argv)`, turning the host binary into a plain
+// interpreter for that multiprocessing helper process only.
+//
+// Command-line shapes the detector is meant to catch:
+//
+//   spawn worker:      [exe, *flags, '-c', 'from multiprocessing.spawn import
+//                       spawn_main; spawn_main(...)', '--multiprocessing-fork']
+//   frozen-style:      [exe, '--multiprocessing-fork', 'k=v', ...]
+//   resource tracker:  [exe, *flags, '-c', 'from multiprocessing.
+//                       resource_tracker import main;main(fd)']
+//   forkserver:        [exe, *flags, '-c', 'from multiprocessing.forkserver
+//                       import main; ...']
+// ---------------------------------------------------------------------------
+
+static int sp_starts_with(const char* s, const char* prefix) {
+    return s && strncmp(s, prefix, strlen(prefix)) == 0;
+}
+
+EXPORT int serious_python_is_mp_invocation(int argc, char** argv) {
+    if (!argv) return 0;
+    for (int i = 1; i < argc; i++) {
+        if (!argv[i]) continue;
+        if (strcmp(argv[i], "--multiprocessing-fork") == 0) {
+            return 1;
+        }
+        if (strcmp(argv[i], "-c") == 0 && i + 1 < argc) {
+            const char* prog = argv[i + 1];
+            // intentionally kept broad/prefix-based to avoid hardcoding
+            if (sp_starts_with(prog, "from multiprocessing.") ||
+                sp_starts_with(prog, "import sys; from multiprocessing.")) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+// Shared preparation before handing the process to Py_Main/Py_BytesMain.
+// Returns 0 to proceed, non-zero exit code on a hard configuration error.
+static int sp_child_preflight(void) {
+    // Prevent re-exec'd multiprocessing children from inheriting PYTHONINSPECT,
+    // or they may stay open in interactive mode after the `-c` helper command finishes.
+    sp_unsetenv("PYTHONINSPECT");
+
+    if (!getenv("PYTHONHOME") && !getenv("PYTHONPATH")) {
+        fprintf(stderr,
+                "[serious_python_main] neither PYTHONHOME nor PYTHONPATH is "
+                "set; the embedded stdlib cannot be located. multiprocessing "
+                "children must inherit the host app's environment.\n");
+        return 64;
+    }
+
+    // Make the built-in dart_bridge module importable in the child too. The child
+    // normally should not talk to Dart, but inherited user/import paths may import
+    // dart_bridge-aware code; the import should fail soft rather than because the
+    // built-in module is missing. Must happen before Py_Main initializes Python.
+    if (PyImport_AppendInittab("dart_bridge", PyInit_dart_bridge) != 0) {
+        fprintf(stderr,
+                "[serious_python_main] inittab append failed for dart_bridge\n");
+        // Non-fatal: proceed without the builtin.
+    }
+    return 0;
+}
+
+// Run this process as a plain CPython interpreter for the given multiprocessing
+// command line. Returns the interpreter's exit code; the caller should exit the
+// process with it without running any other app code.
+//
+// The interpreter locates the embedded stdlib/site-packages through the
+// PYTHONHOME/PYTHONPATH environment variables inherited from the parent
+// process. The parent's `serious_python_run` sets them process-wide before
+// Py_Initialize, so multiprocessing children inherit them.
+EXPORT int serious_python_main(int argc, char** argv) {
+    int rc = sp_child_preflight();
+    if (rc != 0) return rc;
+
+    // Py_BytesMain (stable ABI, 3.8+) runs the full standard interpreter
+    // lifecycle: parses argv (-B/-s/-c/...), honors PYTHONHOME/PYTHONPATH,
+    // executes the '-c' payload with sys.argv = ['-c', *rest] (which is what
+    // multiprocessing.spawn.spawn_main asserts on), and returns the exit
+    // code after finalization.
+    return Py_BytesMain(argc, argv);
+}
+
+#if defined(_WIN32)
+static int sp_wstarts_with(const wchar_t* s, const wchar_t* prefix) {
+    return s && wcsncmp(s, prefix, wcslen(prefix)) == 0;
+}
+
+EXPORT int serious_python_is_mp_invocation_w(int argc, wchar_t** argv) {
+    if (!argv) return 0;
+    for (int i = 1; i < argc; i++) {
+        if (!argv[i]) continue;
+        if (wcscmp(argv[i], L"--multiprocessing-fork") == 0) {
+            return 1;
+        }
+        if (wcscmp(argv[i], L"-c") == 0 && i + 1 < argc) {
+            const wchar_t* prog = argv[i + 1];
+            if (sp_wstarts_with(prog, L"from multiprocessing.") ||
+                sp_wstarts_with(prog, L"import sys; from multiprocessing.")) {
+                return 1;
+            }
+        }
+    }
+    return 0;
+}
+
+EXPORT int serious_python_main_w(int argc, wchar_t** argv) {
+    int rc = sp_child_preflight();
+    if (rc != 0) return rc;
+    return Py_Main(argc, argv);
+}
+#endif


### PR DESCRIPTION
Part of flet-dev/flet#4283. Companion PRs: flet-dev/serious-python#228 (consumes these exports and bumps the pin) and flet-dev/flet#6662 (build-template runners that call them).

## Problem

Python's `multiprocessing` (the `spawn` and `forkserver` start methods, plus the resource tracker) launches helper processes by re-executing `sys.executable` with a CPython command line. In apps embedding Python through this library, `sys.executable` resolves to the host app executable, so every helper re-launched the host GUI instead of running the multiprocessing protocol: one stray window per worker, tasks that never executed, hung joins, and `resource_tracker: process died unexpectedly, relaunching` loops. This has been broken since 2024 and is the core of flet-dev/flet#4283. Notably, Python 3.14 made `forkserver` the default start method on Linux, so packaged Linux apps now hit the broken re-exec path even for code that never selects a start method.

## Solution

Two new stable-ABI exports in `serious_python_run.c` let the host binary double as a plain Python interpreter for exactly those helper invocations:

- `serious_python_is_mp_invocation(argc, argv)` matches `--multiprocessing-fork` anywhere in argv, or a `-c` payload starting with `from multiprocessing.` or `import sys; from multiprocessing.`, covering spawn workers, the resource tracker, and the forkserver on CPython 3.12–3.14. The match is deliberately prefix-based because the exact helper command lines are CPython implementation details that shift across minor releases, while the helpers stay under `multiprocessing.*`.
- `serious_python_main(argc, argv)` runs a shared preflight (scrub inherited `PYTHONINSPECT`, which would otherwise hold a real interpreter child open in interactive mode after its `-c` command; verify `PYTHONHOME`/`PYTHONPATH` are present, which the parent's `serious_python_run` already setenv's process-wide so children inherit the embedded stdlib and site-packages; register the in-binary `dart_bridge` module on the inittab so inherited dart_bridge-aware imports fail soft), then delegates to `Py_BytesMain` for the full standard interpreter lifecycle.

Windows additionally gets wide-char variants `serious_python_is_mp_invocation_w` / `serious_python_main_w` (delegating to `Py_Main`), since `wWinMain` argv is `wchar_t**` and decoding through the ANSI code page in the narrow versions would be lossy.

Host contract (documented in the README): call the detector first thing in `main` / `wWinMain` / `main.swift`, before any UI or engine initialization, and exit with `serious_python_main`'s return code on a match. The flet build template runners do exactly this, resolving the exports via dlsym/GetProcAddress with graceful fallthrough so hosts built against older dart_bridge keep launching unchanged.

The `EXPORT` macro on non-Windows now adds `__attribute__((used))`: on Mach-O the archive is statically linked into the host app and several exports are referenced only via dlsym/Dart FFI, and without the no-dead-strip marker the host link's `-dead_strip` discarded any export lacking a static call site.

## CI fix: glibc floor of Linux artifacts

Artifacts are currently built directly on `ubuntu-24.04` runners (glibc 2.39), so they bind modern symbol versions — e.g. `strtoll` → `__isoc23_strtoll@GLIBC_2.38`. Since the flet build template links `libdart_bridge.so` straight into the app executable, `flet build linux` fails its final link on anything older (reproduced on Ubuntu 22.04 LTS: `clang: error: linker command failed`). This affects the released 1.4.1 Linux artifacts today, independent of new features — worth re-spinning with the next tag.

**Fix**

Build inside a **`debian:10` job container** on modern runners — the same pattern (and lowest tier) as flet's own `build_linux` matrix (`manylinux_2_28`). dart-bridge ships one `.so` per arch, so it must clear the lowest supported tier: a **glibc 2.28 floor** covers Debian 10/11/12, Ubuntu 20.04/22.04/24.04, and RHEL 8+ with a single artifact.

Details (each step is commented in the workflow):

- Debian 10 is EOL → apt pointed at `archive.debian.org`, `Check-Valid-Until` off; git/ca-certs installed before `actions/checkout` (the action runs inside the container).
- Debian 10 ships CMake 3.13 (< our 3.15 minimum) → current CMake from Kitware's official binaries, which run on old glibc.
- **New assertion step**: the job fails if the artifact references any glibc symbol newer than 2.28 — the floor is an enforced contract, so a future container/runner bump can't silently raise it.

## Verification

Verified end-to-end inside `flet build` apps on macOS (arm64), Windows 11 (arm64 host, x64 app), and Ubuntu 22.04 (aarch64): a `Process`+`Queue` round-trip with a worker defined in the app's `main.py`, and a `ProcessPoolExecutor` benchmark with worker reuse, all completing with headless children, correct results, roughly cpu-count speedups, and clean exits, under both the spawn context and Linux's forkserver default. The interception was also smoke-tested directly by invoking the built app binaries with multiprocessing-shaped command lines.

## Release notes

Merging this should be followed by tagging 1.5.0 (semver minor: new exports, no breaking changes), which republishes all platform artifacts including the glibc-2.35-floor Linux ones. flet-dev/python-build's `manifest.json` then bumps `dart_bridge_version` to 1.5.0, and flet-dev/serious-python#228 picks up the regenerated pin. Note that serious-python 4.3.0's darwin plugin hard-requires these exports at link time (dead-strip keep-alives), so the tag must exist before that releases.