### PR TITLE
Fix Windows UTF-8 startup for embedded Python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,12 @@
 name: CI
 
 # Single workflow for both branch/PR validation and tagged-release publish.
-# - push to main / PR / workflow_dispatch  → build all 4 platforms, upload artifacts
-# - tag push (v*.*.*)                       → build + attach artifacts to GitHub Release
+# - push to any branch / PR / workflow_dispatch → build all 4 platforms, upload artifacts
+# - tag push (v*.*.*)                           → build + attach artifacts to GitHub Release
 
 on:
   push:
-    branches: [main]
+    branches: ['**']
     tags: ['v*.*.*']
   pull_request:
   workflow_dispatch:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.4.1 LANGUAGES C)
+project(dart_bridge VERSION 1.5.1 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -86,8 +86,38 @@ static int sp_pyrun_file(FILE *fp, const char *filename) {
 #define EXPORT __declspec(dllexport)
 #define SP_PATH_SEP "\\"
 #define SP_PYPATH_SEP ";"
-static int sp_setenv(const char* k, const char* v) { return _putenv_s(k, v); }
-static int sp_unsetenv(const char* k) { return _putenv_s(k, ""); }
+// Dart passes strings across FFI as UTF-8. On Windows, narrow CRT filesystem
+// and environment APIs reinterpret those bytes through the active ANSI code
+// page, corrupting paths such as C:\Users\Jürgen\... Use wide APIs at the
+// Windows boundary instead. See flet-dev/flet#6641.
+static wchar_t* sp_utf8_to_wide(const char* s) {
+    if (!s) return NULL;
+    int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, NULL, 0);
+    if (wlen <= 0) return NULL;
+    wchar_t* w = (wchar_t*)malloc((size_t)wlen * sizeof(wchar_t));
+    if (!w) return NULL;
+    if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, w, wlen) <= 0) {
+        free(w);
+        return NULL;
+    }
+    return w;
+}
+static int sp_setenv(const char* k, const char* v) {
+    wchar_t* wk = sp_utf8_to_wide(k);
+    wchar_t* wv = sp_utf8_to_wide(v ? v : "");
+    int rc = -1;
+    if (wk && wv) rc = _wputenv_s(wk, wv);
+    free(wk);
+    free(wv);
+    return rc;
+}
+static int sp_unsetenv(const char* k) {
+    wchar_t* wk = sp_utf8_to_wide(k);
+    int rc = -1;
+    if (wk) rc = _wputenv_s(wk, L"");
+    free(wk);
+    return rc;
+}
 #else
 #include <pthread.h>
 #include <unistd.h>
@@ -355,7 +385,17 @@ static int sp_run_target(sp_state_t* st) {
     }
     // SP_RUN_PATH
     if (!st->app_path) return 1;
+#if defined(_WIN32)
+    wchar_t* wpath = sp_utf8_to_wide(st->app_path);
+    FILE* fp = NULL;
+    if (wpath) {
+        errno_t err = _wfopen_s(&fp, wpath, L"rb");
+        if (err != 0) fp = NULL;
+    }
+    free(wpath);
+#else
     FILE* fp = fopen(st->app_path, "rb");
+#endif
     if (!fp) {
         fprintf(stderr, "[serious_python_run] cannot open %s\n", st->app_path);
         return 1;
@@ -461,6 +501,25 @@ static int sp_run_python(sp_state_t* st) {
         }
     }
 #else
+#if defined(_WIN32)
+    // Force UTF-8 Mode before Py_Initialize so Python's default text encoding
+    // is UTF-8 on non-UTF-8 Windows locales. PyPreConfig would be cleaner, but
+    // this desktop path uses Py_LIMITED_API where PyPreConfig is unavailable.
+#if defined(_MSC_VER)
+#  pragma warning(push)
+#  pragma warning(disable : 4996)
+#elif defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+    Py_UTF8Mode = 1;
+#if defined(_MSC_VER)
+#  pragma warning(pop)
+#elif defined(__GNUC__) || defined(__clang__)
+#  pragma GCC diagnostic pop
+#endif
+#endif
+
     Py_Initialize();
 
     if (!Py_IsInitialized()) {
@@ -631,6 +690,12 @@ static int sp_child_preflight(void) {
     // Prevent re-exec'd multiprocessing children from inheriting PYTHONINSPECT,
     // or they may stay open in interactive mode after the `-c` helper command finishes.
     sp_unsetenv("PYTHONINSPECT");
+
+#if defined(_WIN32)
+    // Py_Main/Py_BytesMain read PYTHONUTF8 during their own pre-initialization;
+    // match the parent embedded interpreter for multiprocessing helpers.
+    sp_setenv("PYTHONUTF8", "1");
+#endif
 
     if (!getenv("PYTHONHOME") && !getenv("PYTHONPATH")) {
         fprintf(stderr,

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -94,6 +94,7 @@ static wchar_t* sp_utf8_to_wide(const char* s) {
     if (!s) return NULL;
     int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, NULL, 0);
     if (wlen <= 0) return NULL;
+    if ((size_t)wlen > ((size_t)-1) / sizeof(wchar_t)) return NULL;
     wchar_t* w = (wchar_t*)malloc((size_t)wlen * sizeof(wchar_t));
     if (!w) return NULL;
     if (MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, w, wlen) <= 0) {
@@ -118,6 +119,14 @@ static int sp_unsetenv(const char* k) {
     free(wk);
     return rc;
 }
+static int sp_getenv_present(const char* k) {
+    wchar_t* wk = sp_utf8_to_wide(k);
+    if (!wk) return 0;
+    size_t needed = 0;
+    errno_t rc = _wgetenv_s(&needed, NULL, 0, wk);
+    free(wk);
+    return rc == 0 && needed > 0;
+}
 #else
 #include <pthread.h>
 #include <unistd.h>
@@ -130,6 +139,7 @@ static int sp_unsetenv(const char* k) {
 #define SP_PYPATH_SEP ":"
 static int sp_setenv(const char* k, const char* v) { return setenv(k, v, 1); }
 static int sp_unsetenv(const char* k) { return unsetenv(k); }
+static int sp_getenv_present(const char* k) { return getenv(k) != NULL; }
 #endif
 
 // PyInit_dart_bridge lives in dart_bridge.c, linked into the same binary.
@@ -710,7 +720,7 @@ static int sp_child_preflight(void) {
     sp_setenv("PYTHONUTF8", "1");
 #endif
 
-    if (!getenv("PYTHONHOME") && !getenv("PYTHONPATH")) {
+    if (!sp_getenv_present("PYTHONHOME") && !sp_getenv_present("PYTHONPATH")) {
         fprintf(stderr,
                 "[serious_python_main] neither PYTHONHOME nor PYTHONPATH is "
                 "set; the embedded stdlib cannot be located. multiprocessing "

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -294,10 +294,15 @@ static sp_state_t* sp_state_from_config(const sp_run_config_t* cfg) {
 
 // Apply env vars BEFORE Py_Initialize so PYTHONHOME / PYTHONPATH / etc. are
 // observed during interpreter startup.
-static void sp_apply_env(sp_state_t* st) {
+static int sp_apply_env(sp_state_t* st) {
     for (size_t i = 0; i < st->env_count; i++) {
-        sp_setenv(st->env_keys[i], st->env_values[i]);
+        if (sp_setenv(st->env_keys[i], st->env_values[i]) != 0) {
+            fprintf(stderr, "[serious_python_run] failed to set env var %s\n",
+                    st->env_keys[i] ? st->env_keys[i] : "<null>");
+            return -1;
+        }
     }
+    return 0;
 }
 
 // Register dart_bridge + any user-registered extensions with the inittab.
@@ -472,12 +477,16 @@ static int sp_run_python(sp_state_t* st) {
     //    FletDartBridgeServer restart loop, the python.dart sys.exit
     //    patcher) can rewire to them.
     if (Py_IsInitialized()) {
-        sp_apply_env(st);
+        if (sp_apply_env(st) != 0) {
+            return 1;
+        }
         sp_signal_session_from_env(st);
         return 0;
     }
 
-    sp_apply_env(st);
+    if (sp_apply_env(st) != 0) {
+        return 1;
+    }
 
     if (sp_apply_inittab() != 0) {
         return 1;

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -86,10 +86,10 @@ static int sp_pyrun_file(FILE *fp, const char *filename) {
 #define EXPORT __declspec(dllexport)
 #define SP_PATH_SEP "\\"
 #define SP_PYPATH_SEP ";"
-// Dart passes strings across FFI as UTF-8. On Windows, narrow CRT filesystem
-// and environment APIs reinterpret those bytes through the active ANSI code
-// page, corrupting paths such as C:\Users\Jürgen\... Use wide APIs at the
-// Windows boundary instead. See flet-dev/flet#6641.
+// Dart passes FFI strings as UTF-8. On Windows, narrow CRT APIs interpret
+// char* paths and environment values using the process ANSI code page, so
+// non-ASCII paths can be corrupted. Convert to UTF-16 at the OS/CRT boundary
+// and use the wide APIs instead.
 static wchar_t* sp_utf8_to_wide(const char* s) {
     if (!s) return NULL;
     int wlen = MultiByteToWideChar(CP_UTF8, MB_ERR_INVALID_CHARS, s, -1, NULL, 0);
@@ -292,8 +292,10 @@ static sp_state_t* sp_state_from_config(const sp_run_config_t* cfg) {
 // Python lifecycle
 // ---------------------------------------------------------------------------
 
-// Apply env vars BEFORE Py_Initialize so PYTHONHOME / PYTHONPATH / etc. are
-// observed during interpreter startup.
+// Apply env vars before Python startup so PYTHONHOME, PYTHONPATH, and runtime
+// bridge ports are visible during initialization. Treat failures as fatal;
+// continuing with a partially configured embedded interpreter gives misleading
+// startup errors.
 static int sp_apply_env(sp_state_t* st) {
     for (size_t i = 0; i < st->env_count; i++) {
         if (sp_setenv(st->env_keys[i], st->env_values[i]) != 0) {
@@ -511,9 +513,10 @@ static int sp_run_python(sp_state_t* st) {
     }
 #else
 #if defined(_WIN32)
-    // Force UTF-8 Mode before Py_Initialize so Python's default text encoding
-    // is UTF-8 on non-UTF-8 Windows locales. PyPreConfig would be cleaner, but
-    // this desktop path uses Py_LIMITED_API where PyPreConfig is unavailable.
+    // Force Python UTF-8 Mode before Py_Initialize so the embedded interpreter
+    // uses UTF-8 for default text encoding on Windows locales whose ANSI code
+    // page is not UTF-8. PyPreConfig would be the modern API, but this path is
+    // built with Py_LIMITED_API, where PyPreConfig is unavailable.
 #if defined(_MSC_VER)
 #  pragma warning(push)
 #  pragma warning(disable : 4996)
@@ -701,8 +704,9 @@ static int sp_child_preflight(void) {
     sp_unsetenv("PYTHONINSPECT");
 
 #if defined(_WIN32)
-    // Py_Main/Py_BytesMain read PYTHONUTF8 during their own pre-initialization;
-    // match the parent embedded interpreter for multiprocessing helpers.
+    // Py_Main/Py_BytesMain run their own pre-initialization and read PYTHONUTF8
+    // from the environment. Set it here so multiprocessing helper processes
+    // match the parent interpreter's UTF-8 behavior.
     sp_setenv("PYTHONUTF8", "1");
 #endif
 


### PR DESCRIPTION
Fixes Windows startup handling for embedded Python when app paths or runtime environment values contain non-ASCII characters.

This PR updates the Windows boundary in `serious_python_run.c` so Dart FFI strings, which arrive as UTF-8, are converted to UTF-16 before calling Windows CRT APIs. This avoids corrupting paths/environment values through the process ANSI code page.

Closes flet-dev/flet#6641

## Changes

- Convert UTF-8 strings to UTF-16 on Windows before setting/unsetting environment variables.
- Use `_wputenv_s` instead of `_putenv_s` on Windows.
- Open `SP_RUN_PATH` with `_wfopen_s` on Windows.
- Enable Python UTF-8 Mode before `Py_Initialize()` on Windows.
- Set `PYTHONUTF8=1` for Windows multiprocessing helper processes.
- Treat embedded env setup failures as fatal instead of continuing with partial configuration.
