### PR TITLE
Apple: build dart_bridge as a dynamic framework (1.6.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,29 @@
+# Changelog
+
+## 1.6.0
+
+### Apple: `dart_bridge.xcframework` is now a dynamic framework
+
+`apple/build_xcframework.sh` now produces `dart_bridge.xcframework` as a **dynamic
+framework** (a `.framework` with a dylib) instead of a static library.
+
+**Why.** The FFI entry points (`serious_python_run`, `DartBridge_InitDartApiDL`,
+`DartBridge_EnqueueMessage`, `PyInit_dart_bridge`) are resolved at runtime via
+`dlsym` — Dart's `DynamicLibrary.process()` and Python's `import dart_bridge`. A
+static library linked into the host app **executable** does not export its symbols
+(an iOS executable exports nothing by default, and the release build strips local
+symbols), so `dlsym(RTLD_DEFAULT)` could not find them and release/device builds
+crashed at startup with `Failed to lookup symbol 'serious_python_run'`. A dynamic
+framework exports its default-visibility symbols and is loaded as its own image,
+so `dlsym` resolves them — matching the Android `.so` (CMake `add_library(...
+SHARED)`) that already worked. Only release/archive (device) builds were affected;
+debug/simulator builds don't dead-strip and appeared to work.
+
+**Consumer impact.** `serious_python_darwin` embeds + signs the framework (as it
+already does for `Python.xcframework`) instead of static-linking it — no
+`-all_load`/`-force_load` retention or dead-strip keep-alive is needed anymore.
+`Py_*`/`Dart_*` symbols are left undefined (`-undefined dynamic_lookup`) and bound
+at load time from the app's embedded `Python.framework` and the Dart runtime.
+
+The Linux, Windows, and Android builds are unchanged (already dynamic via
+CMake `SHARED`).

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.5.1 LANGUAGES C)
+project(dart_bridge VERSION 1.6.0 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/apple/build_xcframework.sh
+++ b/apple/build_xcframework.sh
@@ -1,15 +1,27 @@
 #!/usr/bin/env bash
 #
-# Build dart_bridge.xcframework — a multi-slice static library for Apple
+# Build dart_bridge.xcframework — a multi-slice DYNAMIC framework for Apple
 # platforms (iOS device, iOS simulator, macOS) consumed by serious_python_darwin.
+#
+# Why dynamic (a .framework with a dylib) and not a static library:
+#   The FFI entry points (serious_python_run, DartBridge_InitDartApiDL,
+#   DartBridge_EnqueueMessage, PyInit_dart_bridge) are resolved at runtime via
+#   dlsym — Dart's `DynamicLibrary.process()` and Python's `import dart_bridge`.
+#   A STATIC library linked into the host app executable does NOT export its
+#   symbols (an iOS executable exports nothing by default, and the release build
+#   strips local symbols), so dlsym(RTLD_DEFAULT) cannot find them and the app
+#   crashes at startup with "Failed to lookup symbol 'serious_python_run'". A
+#   dynamic framework exports its default-visibility symbols and is loaded as its
+#   own image, so dlsym resolves them — exactly like the Android `.so` build
+#   (CMake `add_library(... SHARED)`), which is why Android already works.
 #
 # Requires:
 #   - Xcode (xcrun, xcodebuild)
-#   - $PYTHON_HEADERS_DIR set to a directory containing Python.h. Typically
-#     extracted from python-ios-dart-${V}.tar.gz / python-macos-dart-${V}.tar.gz.
-#   - The xcframework's static libs export PyInit_dart_bridge but the
-#     consuming app (via serious_python_darwin) brings the actual Python
-#     framework that resolves Py* symbols at app link time.
+#   - $PYTHON_HEADERS_DIR set to a directory containing Python.h.
+#   - Py_* and Dart_* symbols are left undefined (`-undefined dynamic_lookup`)
+#     and resolved at runtime from the app's embedded Python.framework and the
+#     Flutter/Dart runtime — the same deferral the static build relied on at app
+#     link time, now deferred to load time instead.
 #
 # Output: dist/dart_bridge.xcframework + dist/dart_bridge-apple.xcframework.zip
 
@@ -31,15 +43,45 @@ SRC_FILES=(
   "$ROOT/src/dart_api/dart_api_dl.c"
 )
 
-# Compile per-arch object files for each (sdk, arch) tuple, then libtool them
-# into per-slice static archives. Slices match Apple's xcframework conventions:
-#
-#   iphoneos:        arm64                 (real iOS devices)
-#   iphonesimulator: arm64 x86_64          (Apple Silicon + Intel sims)
-#   macosx:          arm64 x86_64          (Apple Silicon + Intel macOS)
+FW_NAME="dart_bridge"
+BUNDLE_ID="dev.flet.dartbridge"
+FW_VERSION="1.0"
 
+# Emit a minimal framework Info.plist. $1 = dest file, $2 = platform name
+# (iPhoneOS / iPhoneSimulator / MacOSX), $3 = min OS version.
+write_info_plist() {
+  local dest="$1" platform="$2" minos="$3"
+  cat > "$dest" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>CFBundleDevelopmentRegion</key><string>en</string>
+  <key>CFBundleExecutable</key><string>${FW_NAME}</string>
+  <key>CFBundleIdentifier</key><string>${BUNDLE_ID}</string>
+  <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+  <key>CFBundleName</key><string>${FW_NAME}</string>
+  <key>CFBundlePackageType</key><string>FMWK</string>
+  <key>CFBundleShortVersionString</key><string>${FW_VERSION}</string>
+  <key>CFBundleVersion</key><string>${FW_VERSION}</string>
+  <key>CFBundleSupportedPlatforms</key><array><string>${platform}</string></array>
+  <key>MinimumOSVersion</key><string>${minos}</string>
+</dict>
+</plist>
+PLIST
+}
+
+# Build a dynamic .framework for one slice.
+#   $1 = sdk (iphoneos|iphonesimulator|macosx)
+#   $2 = platform name for Info.plist
+#   $3 = min OS version
+#   $4 = "flat" (iOS) or "versioned" (macOS) framework layout
+#   $5.. = archs
 build_slice() {
   local sdk="$1"; shift
+  local platform="$1"; shift
+  local minos="$1"; shift
+  local layout="$1"; shift
   local archs=("$@")
 
   echo "--- Building slice: $sdk (${archs[*]}) ---"
@@ -53,66 +95,73 @@ build_slice() {
     macosx)          min_flag="-mmacosx-version-min=10.15" ;;
   esac
 
-  # For each arch, produce a per-arch static archive. xcframework slices
-  # must be either single-arch archives OR a single fat (lipo'd) archive
-  # per slice. libtool-static of multi-arch .o files in one archive
-  # produces a multi-platform archive that xcodebuild -create-xcframework
-  # rejects ("binaries with multiple platforms are not supported"), so we
-  # libtool per-arch and then lipo the per-arch archives into one fat .a.
+  local arch_flags=()
+  local a
+  for a in "${archs[@]}"; do arch_flags+=(-arch "$a"); done
 
-  local arch_archives=()
-  for arch in "${archs[@]}"; do
-    local arch_objs=()
-    for src in "${SRC_FILES[@]}"; do
-      local name
-      name=$(basename "$src" .c)
-      local obj="$BUILD/$sdk-$arch-$name.o"
-      xcrun --sdk "$sdk" clang \
-        -arch "$arch" \
-        -isysroot "$sdk_path" \
-        $min_flag \
-        -DPy_LIMITED_API=0x030c0000 \
-        -DDART_SHARED_LIB \
-        -fvisibility=hidden \
-        -I "$PYTHON_HEADERS_DIR" \
-        -I "$ROOT/src" \
-        -c "$src" -o "$obj"
-      arch_objs+=("$obj")
-    done
-    local arch_archive="$BUILD/libdart_bridge-$sdk-$arch.a"
-    libtool -static -o "$arch_archive" "${arch_objs[@]}"
-    arch_archives+=("$arch_archive")
+  # Compile each source once as a fat (multi-arch) object.
+  local objs=()
+  local src name obj
+  for src in "${SRC_FILES[@]}"; do
+    name=$(basename "$src" .c)
+    obj="$BUILD/$sdk-$name.o"
+    xcrun --sdk "$sdk" clang \
+      "${arch_flags[@]}" \
+      -isysroot "$sdk_path" \
+      $min_flag \
+      -DPy_LIMITED_API=0x030c0000 \
+      -DDART_SHARED_LIB \
+      -fvisibility=hidden \
+      -I "$PYTHON_HEADERS_DIR" \
+      -I "$ROOT/src" \
+      -c "$src" -o "$obj"
+    objs+=("$obj")
   done
 
-  # CocoaPods rejects xcframeworks whose slices have differing library
-  # binary names ("contains static libraries with differing binary names").
-  # Stage each slice under its own subdir so xcodebuild -create-xcframework
-  # preserves a uniform `libdart_bridge.a` in every slice.
-  local slice_dir="$BUILD/$sdk"
-  mkdir -p "$slice_dir"
-  local slice_archive="$slice_dir/libdart_bridge.a"
-  if [ "${#arch_archives[@]}" -eq 1 ]; then
-    cp "${arch_archives[0]}" "$slice_archive"
+  # Link a fat dynamic library. Py_*/Dart_* stay undefined and are bound at
+  # load time from the app's Python.framework and the Dart runtime.
+  local dylib="$BUILD/$sdk-$FW_NAME.dylib"
+  xcrun --sdk "$sdk" clang \
+    -dynamiclib \
+    "${arch_flags[@]}" \
+    -isysroot "$sdk_path" \
+    $min_flag \
+    -install_name "@rpath/${FW_NAME}.framework/${FW_NAME}" \
+    -Wl,-undefined,dynamic_lookup \
+    -o "$dylib" "${objs[@]}"
+
+  # Assemble the .framework bundle.
+  local fw="$BUILD/$sdk/${FW_NAME}.framework"
+  rm -rf "$fw"
+  if [ "$layout" = "versioned" ]; then
+    mkdir -p "$fw/Versions/A/Resources"
+    cp "$dylib" "$fw/Versions/A/${FW_NAME}"
+    write_info_plist "$fw/Versions/A/Resources/Info.plist" "$platform" "$minos"
+    ln -sfn A "$fw/Versions/Current"
+    ln -sfn "Versions/Current/${FW_NAME}" "$fw/${FW_NAME}"
+    ln -sfn "Versions/Current/Resources" "$fw/Resources"
   else
-    lipo -create -output "$slice_archive" "${arch_archives[@]}"
+    mkdir -p "$fw"
+    cp "$dylib" "$fw/${FW_NAME}"
+    write_info_plist "$fw/Info.plist" "$platform" "$minos"
   fi
-  echo "  -> $slice_archive"
-  lipo -info "$slice_archive" 2>/dev/null || true
+  echo "  -> $fw"
+  lipo -info "$dylib" 2>/dev/null || true
 }
 
-build_slice iphoneos arm64
-build_slice iphonesimulator arm64 x86_64
-build_slice macosx arm64 x86_64
+build_slice iphoneos        iPhoneOS        13.0  flat      arm64
+build_slice iphonesimulator iPhoneSimulator 13.0  flat      arm64 x86_64
+build_slice macosx          MacOSX          10.15 versioned arm64 x86_64
 
 echo "--- Creating xcframework ---"
 xcodebuild -create-xcframework \
-  -library "$BUILD/iphoneos/libdart_bridge.a" \
-  -library "$BUILD/iphonesimulator/libdart_bridge.a" \
-  -library "$BUILD/macosx/libdart_bridge.a" \
-  -output "$DIST/dart_bridge.xcframework"
+  -framework "$BUILD/iphoneos/${FW_NAME}.framework" \
+  -framework "$BUILD/iphonesimulator/${FW_NAME}.framework" \
+  -framework "$BUILD/macosx/${FW_NAME}.framework" \
+  -output "$DIST/${FW_NAME}.xcframework"
 
 echo "--- Zipping artifact ---"
-(cd "$DIST" && zip -qr dart_bridge-apple.xcframework.zip dart_bridge.xcframework)
+(cd "$DIST" && zip -qr "${FW_NAME}-apple.xcframework.zip" "${FW_NAME}.xcframework")
 
-echo "Done: $DIST/dart_bridge-apple.xcframework.zip"
-ls -lh "$DIST/dart_bridge-apple.xcframework.zip"
+echo "Done: $DIST/${FW_NAME}-apple.xcframework.zip"
+ls -lh "$DIST/${FW_NAME}-apple.xcframework.zip"


### PR DESCRIPTION
## Summary

Builds `dart_bridge.xcframework` for Apple platforms as a **dynamic framework** (a `.framework` with a dylib) instead of a static library. Bumps the version to **1.6.0**.

## Why

The FFI entry points — `serious_python_run`, `DartBridge_InitDartApiDL`, `DartBridge_EnqueueMessage`, `PyInit_dart_bridge` — are resolved at runtime via `dlsym` (Dart's `DynamicLibrary.process()` and Python's `import dart_bridge`).

A **static** library linked into the host app **executable** does not export its symbols: an iOS executable exports nothing to the dynamic symbol table by default, and the release build strips local symbols. So `dlsym(RTLD_DEFAULT)` couldn't find them, and release/device builds crashed at startup with:

```
Failed to lookup symbol 'serious_python_run': dlsym(RTLD_DEFAULT, serious_python_run): symbol not found
```

Debug/simulator builds don't dead-strip, so they appeared to work — the failure was release/archive (device) only. This is exactly why **Android already worked** (its CMake build is `add_library(... SHARED)` → a dynamic `.so` that exports its symbols) while iOS did not.

A **dynamic framework** exports its default-visibility symbols and is loaded as its own image, so `dlsym` resolves them — bringing Apple in line with Android.

## What changed

- `apple/build_xcframework.sh`: compile the three C sources per slice, then **link a dylib** (`-dynamiclib`, `install_name @rpath/dart_bridge.framework/dart_bridge`) and wrap it in a `.framework` (flat layout for iOS device/simulator, versioned for macOS), then `-create-xcframework` from the frameworks. `Py_*`/`Dart_*` stay undefined (`-undefined dynamic_lookup`) and bind at load time from the app's embedded `Python.framework` and the Dart runtime — the same deferral the static build relied on at app link time, now at load time.
- `CMakeLists.txt`: version → 1.6.0.
- `CHANGELOG.md`: added (documents the change + consumer impact).

The Linux/Windows/Android builds are unchanged. The output artifact name (`dist/dart_bridge-apple.xcframework.zip`) and the CI `build-apple` job are unchanged.

## Consumer impact

`serious_python_darwin` embeds + signs the framework (as it already does for `Python.xcframework`) instead of static-linking it — no `-all_load`/`-force_load` retention or dead-strip keep-alive needed. A matching `serious_python` change lands separately.

## Verified

Built the iOS-device slice locally and confirmed the dylib's export trie contains `serious_python_run`, `DartBridge_InitDartApiDL`, `DartBridge_EnqueueMessage`, `PyInit_dart_bridge` with `install_name @rpath/dart_bridge.framework/dart_bridge`. End-to-end: a Flet iOS release app that embeds it boots on-device and resolves the symbols (previously crashed at startup).

## Note

`-undefined dynamic_lookup` warns "deprecated on iOS." It works and matches how CPython extension modules link, but App Store acceptance is worth confirming; the alternative is linking the dylib against `Python.framework` explicitly.
