### PR TITLE
Apple: preserve framework symlinks in the published zip (1.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,23 @@
 # Changelog
 
+## 1.6.1
+
+### Apple: preserve framework symlinks in the published zip
+
+`apple/build_xcframework.sh` now zips with `-y`, storing symlinks as symlinks.
+
+Without it `zip` follows symlinks, so the macOS slice's versioned bundle —
+`Versions/Current -> A`, `dart_bridge -> Versions/Current/dart_bridge`,
+`Resources -> Versions/Current/Resources` — extracted as real files and
+directories (and stored the dylib three times). The result is a malformed
+framework: macOS builds failed with `Couldn't resolve framework symlink for
+.../Versions/Current` and `code object is not signed at all` /
+`Command CodeSign failed with a nonzero exit code`.
+
+Only macOS was affected — the iOS slices use a flat framework layout with no
+symlinks, which is why iOS builds against 1.6.0 succeeded. The compiled binaries
+are identical to 1.6.0; only the packaging of the published artifact changed.
+
 ## 1.6.0
 
 ### Apple: `dart_bridge.xcframework` is now a dynamic framework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.6.0 LANGUAGES C)
+project(dart_bridge VERSION 1.6.1 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/apple/build_xcframework.sh
+++ b/apple/build_xcframework.sh
@@ -161,7 +161,14 @@ xcodebuild -create-xcframework \
   -output "$DIST/${FW_NAME}.xcframework"
 
 echo "--- Zipping artifact ---"
-(cd "$DIST" && zip -qr "${FW_NAME}-apple.xcframework.zip" "${FW_NAME}.xcframework")
+# -y stores symlinks AS symlinks. Without it zip follows them, and the macOS
+# slice's versioned bundle (`Versions/Current -> A`, `dart_bridge ->
+# Versions/Current/dart_bridge`, `Resources -> Versions/Current/Resources`)
+# extracts as real files/directories — a malformed framework that macOS codesign
+# rejects ("Couldn't resolve framework symlink for .../Versions/Current",
+# "code object is not signed at all"), and that stores the dylib three times.
+# iOS uses a flat layout with no symlinks, so only macOS was affected.
+(cd "$DIST" && zip -qry "${FW_NAME}-apple.xcframework.zip" "${FW_NAME}.xcframework")
 
 echo "Done: $DIST/${FW_NAME}-apple.xcframework.zip"
 ls -lh "$DIST/${FW_NAME}-apple.xcframework.zip"


### PR DESCRIPTION
Fixes macOS builds against the 1.6.0 artifact. Bumps to **1.6.1**.

## The failure

Both macOS jobs (spm and cocoapods) in [serious-python#240 CI](https://github.com/flet-dev/serious-python/actions/runs/30176090562) failed:

```
warning: Couldn't resolve framework symlink for '.../dart_bridge.xcframework/macos-arm64_x86_64/dart_bridge.framework/Versions/Current':
         The file "Current" couldn't be opened.
.../serious_python_bridge_example.app: code object is not signed at all
In subcomponent: .../Contents/Frameworks/dart_bridge.framework
Command CodeSign failed with a nonzero exit code
```

All iOS jobs (spm + cocoapods) passed.

## Cause

`zip` without `-y` **follows** symlinks. The macOS slice is a versioned framework bundle, so its three symlinks —

```
Versions/Current -> A
dart_bridge      -> Versions/Current/dart_bridge
Resources        -> Versions/Current/Resources
```

— were stored as real files/directories, and the dylib ended up in the archive three times. Inspecting the published 1.6.0 asset confirms it:

```
$ unzip -l dart_bridge-apple.xcframework.zip | grep macos
124472  .../dart_bridge.framework/dart_bridge            <- should be a symlink
124472  .../dart_bridge.framework/Versions/A/dart_bridge
124472  .../dart_bridge.framework/Versions/Current/dart_bridge   <- Current should be a symlink to A
```

macOS codesign rejects that bundle shape. The iOS slices use a **flat** framework layout with no symlinks, which is exactly why iOS was unaffected.

## Fix

`zip -qr` → `zip -qry`. Compiled binaries are unchanged from 1.6.0; only the packaging of the published artifact differs.

## Verification

1.6.0 shipped this macOS path untested (the local build had stopped at an earlier slice), so I exercised it fully this time:

1. Compile the three sources universal (`arm64` + `x86_64`) → `lipo -info` confirms both.
2. Assemble the versioned framework, run `xcodebuild -create-xcframework` → symlinks preserved.
3. `zip -qry` then `unzip` → symlinks preserved (`Current -> A`, `dart_bridge -> Versions/Current/dart_bridge`, `Resources -> Versions/Current/Resources`). Reproduced the old behavior side by side to confirm `-y` is what makes the difference.
4. `codesign --force --sign -` the extracted framework → succeeds; `codesign --verify --verbose` → **"valid on disk"**, **"satisfies its Designated Requirement"** (this is the step that failed in CI).
5. Export trie still carries all the FFI entry points.

## Downstream

serious-python#240 pins `dart_bridge_version` via python-build's manifest, so landing this needs: tag **v1.6.1** → python-build manifest `dart_bridge_version: 1.6.1` + release → serious_python regenerates its version tables and re-pins.
