### PR TITLE
Find slice frameworks by glob, not by the xcframework's name

### DIFF
--- a/apple/xcframework_signing.sh
+++ b/apple/xcframework_signing.sh
@@ -124,16 +124,13 @@ xcf_find() {
 # depends on the consuming application.
 xcf_signing_identifier() {
     local xcf=$1
-    local name plist ident
-    name=$(basename "$xcf" .xcframework)
+    local fw plist ident
 
-    local slice
-    for slice in "$xcf"/*/; do
-        [ -d "$slice$name.framework" ] || continue
+    while IFS= read -r fw; do
+        [ -n "$fw" ] || continue
         # Flat (iOS) layout, then versioned (macOS). Versions/Current is a
         # symlink to the real version directory, so skip it.
-        for plist in "$slice$name.framework/Info.plist" \
-                     "$slice$name.framework"/Versions/*/Resources/Info.plist; do
+        for plist in "$fw/Info.plist" "$fw"/Versions/*/Resources/Info.plist; do
             [ -f "$plist" ] || continue
             case "$plist" in */Versions/Current/*) continue ;; esac
             ident=$(plutil -extract CFBundleIdentifier raw -o - "$plist" 2>/dev/null) || continue
@@ -142,19 +139,27 @@ xcf_signing_identifier() {
                 return 0
             fi
         done
-    done
+    done <<EOF
+$(xcf_slice_frameworks "$xcf")
+EOF
     return 1
 }
 
-# Emit the per-slice <Name>.framework bundles inside an xcframework.
+# Emit the per-slice .framework bundles inside an xcframework.
+#
+# Found by globbing each slice directory rather than by assuming the framework is
+# named after the xcframework. The two normally match, but a consumer may stage a
+# copy under a different name -- serious_python renames Python.xcframework to
+# Python-<platform>.xcframework -- and a name-keyed lookup silently finds nothing
+# there, which would let an unsigned slice pass as "no slices to check".
 xcf_slice_frameworks() {
     local xcf=$1
-    local name
-    name=$(basename "$xcf" .xcframework)
-
-    local slice
+    local slice fw
     for slice in "$xcf"/*/; do
-        [ -d "$slice$name.framework" ] && printf '%s\n' "$slice$name.framework"
+        [ -d "$slice" ] || continue
+        for fw in "$slice"*.framework; do
+            [ -d "$fw" ] && printf '%s\n' "$fw"
+        done
     done
     return 0
 }


### PR DESCRIPTION
Small robustness follow-up to #14. **No version bump** — verification only, the signed output is unchanged.

## What was wrong

`xcf_slice_frameworks` located each slice's bundle as `<slice>/<xcframework basename>.framework`. That holds for everything this repo publishes, but it fails *silently* rather than loudly when it doesn't: a consumer staging a copy under a different name — `serious_python` renames `Python.xcframework` to `Python-<platform>.xcframework` — finds no slices at all, and an unsigned inner framework there gets reported as `no slice frameworks found` rather than as unsigned.

Found while building a negative control for #14. I copied the bundle to `/tmp/broken.xcframework`, stripped an inner `_CodeSignature`, and got the wrong error — the rename, not the missing signature, was what the verifier noticed. A check that can be defeated by renaming a directory isn't much of a check.

## The fix

Glob `<slice>/*.framework` instead. `xcf_signing_identifier` now walks the same enumerator rather than repeating the name-keyed lookup.

## Tested

| case | result |
| :--- | :--- |
| published v1.7.1, unmodified | passes |
| same bundle renamed to `Python-ios.xcframework` | passes — slices still found |
| inner `_CodeSignature` stripped, name preserved | fails: `inner framework is unsigned` |
| inner `_CodeSignature` stripped, bundle renamed | fails: `inner framework is unsigned` |

The last row is the one that motivated this; before the change it reported the misleading `no slice frameworks found`.

## v1.7.1 is fine

Confirmed on the published artifact, so no re-release is needed:

```
ios-arm64                    dev.flet.dartbridge  Timestamp Jul 30 1:37:13 PM  Apple Distribution: Appveyor Systems Inc. (GXXRQJK434)
ios-arm64_x86_64-simulator   dev.flet.dartbridge  Timestamp Jul 30 1:37:13 PM  Apple Distribution: Appveyor Systems Inc. (GXXRQJK434)
macos-arm64_x86_64           dev.flet.dartbridge  Timestamp Jul 30 1:37:13 PM  Apple Distribution: Appveyor Systems Inc. (GXXRQJK434)
outer                        dev.flet.dartbridge  Timestamp Jul 30 1:37:13 PM  Sealed Resources files=12
```

Structural parity with the accepted OpenSSL artifact — 3/3 slices signed and timestamped, outer signed and timestamped, versioned macOS symlinks intact through the zip round trip.

The same change is going onto flet-dev/python-build#38, which hasn't merged yet.