### PR TITLE
Detect an inner framework's signature without assuming Versions/A

### DIFF
--- a/apple/xcframework_signing.sh
+++ b/apple/xcframework_signing.sh
@@ -285,7 +285,12 @@ xcf_verify_one() {
     local fw count=0
     while IFS= read -r fw; do
         [ -n "$fw" ] || continue
-        if [ ! -d "$fw/_CodeSignature" ] && [ ! -d "$fw/Versions/A/_CodeSignature" ]; then
+        # `codesign -dv` rather than probing for a _CodeSignature directory: a
+        # versioned bundle keeps it at Versions/<name>/_CodeSignature, and the
+        # version directory is not always "A" (CPython's macOS framework uses the
+        # Python version, e.g. Versions/3.14). codesign exits non-zero with
+        # "code object is not signed at all", which is the question being asked.
+        if ! codesign -dv "$fw" >/dev/null 2>&1; then
             xcf_err "$fw: inner framework is unsigned"
             return 1
         fi


### PR DESCRIPTION
Verification-only, **no version bump** — v1.7.1 is unaffected and needs no re-release.

## What was wrong

`xcf_verify_one` probed for `_CodeSignature` or `Versions/A/_CodeSignature`. A versioned bundle keeps its signature at `Versions/<name>/_CodeSignature`, and the version directory is **not always `A`** — CPython's macOS framework uses the Python version, e.g. `Versions/3.14`. A correctly signed framework there was reported as unsigned.

dart_bridge's own macOS slice does use `Versions/A`, which is why this never fired here. It surfaced in python-build, whose `Python.framework` doesn't — see [python-build#39](https://github.com/flet-dev/python-build/pull/39), where a real signing run produced a valid Apple Distribution signature with a secure timestamp and then failed verification for this reason.

## The fix

Ask `codesign -dv`. It exits non-zero with *"code object is not signed at all"*, which is precisely the question being asked, and it doesn't care where the bundle keeps its `_CodeSignature`.

## Verified

| case | result |
| :--- | :--- |
| published v1.7.1 (`Versions/A`) | still verifies |
| macOS `Python.framework` (`Versions/3.14`), freshly signed | now verifies |
| inner signature stripped | still fails |

Keeps this helper byte-identical to python-build's copy.