### PR TITLE
Register module paths as site directories; dedupe `sys.path` (1.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,34 +2,14 @@
 
 ## 1.8.0
 
-### Module paths are site directories: `.pth` files now work in bundled site-packages
+### Process `.pth` files in bundled site-packages
 
-CPython only processes `.pth` files for *site directories* — the
-`Lib/site-packages` under `PYTHONHOME` — and never for `PYTHONPATH` entries.
-Every `serious_python_*` plugin exposes the app's bundled `site-packages` to the
-interpreter through `PYTHONPATH` / `module_paths`, so any package that relies
-on a `.pth` file to extend `sys.path` or run bootstrap code silently broke in
-a packaged app.
-
-pywin32 is the canonical case ([flet-dev/flet#5071](https://github.com/flet-dev/flet/issues/5071)):
-`pywin32.pth` adds `win32`, `win32\lib` and `pythonwin` to `sys.path` and
-imports `pywin32_bootstrap`, which registers `pywin32_system32` as a DLL
-directory. Without it, `import win32com` in a `flet build windows` app failed
-with `ModuleNotFoundError: No module named 'pywintypes'`.
-
-`serious_python_run` now registers every `module_paths` entry with
-`site.addsitedir()` after inserting it into `sys.path`. `.pth` path lines are
-appended after the existing entries, exactly as in a regular installation;
-entries that are not directories (Android zips, an absent `__pypackages__`)
-are skipped.
-
-### `sys.path` no longer contains every module path twice
-
-The plugins pass the same list both as `PYTHONPATH` (consumed by
-`Py_Initialize`) and as `module_paths` (inserted post-init), so every entry
-showed up on `sys.path` twice. Existing occurrences are now removed — compared
-case- and separator-insensitively — before the list is re-inserted at the
-front, preserving the caller's precedence order.
+Register module paths as site directories so CPython processes their `.pth`
+files. This fixes packages such as pywin32, whose `.pth` file configures its
+module and DLL paths ([flet-dev/flet#5071](https://github.com/flet-dev/flet/issues/5071)).
+Duplicate `sys.path` entries created by supplying the paths through both
+`PYTHONPATH` and `module_paths` are also removed without changing their
+precedence.
 
 ## 1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,36 @@
 # Changelog
 
+## 1.8.0
+
+### Module paths are site directories: `.pth` files now work in bundled site-packages
+
+CPython only processes `.pth` files for *site directories* — the
+`Lib/site-packages` under `PYTHONHOME` — and never for `PYTHONPATH` entries.
+Every `serious_python_*` plugin exposes the app's bundled `site-packages` to the
+interpreter through `PYTHONPATH` / `module_paths`, so any package that relies
+on a `.pth` file to extend `sys.path` or run bootstrap code silently broke in
+a packaged app.
+
+pywin32 is the canonical case ([flet-dev/flet#5071](https://github.com/flet-dev/flet/issues/5071)):
+`pywin32.pth` adds `win32`, `win32\lib` and `pythonwin` to `sys.path` and
+imports `pywin32_bootstrap`, which registers `pywin32_system32` as a DLL
+directory. Without it, `import win32com` in a `flet build windows` app failed
+with `ModuleNotFoundError: No module named 'pywintypes'`.
+
+`serious_python_run` now registers every `module_paths` entry with
+`site.addsitedir()` after inserting it into `sys.path`. `.pth` path lines are
+appended after the existing entries, exactly as in a regular installation;
+entries that are not directories (Android zips, an absent `__pypackages__`)
+are skipped.
+
+### `sys.path` no longer contains every module path twice
+
+The plugins pass the same list both as `PYTHONPATH` (consumed by
+`Py_Initialize`) and as `module_paths` (inserted post-init), so every entry
+showed up on `sys.path` twice. Existing occurrences are now removed — compared
+case- and separator-insensitively — before the list is re-inserted at the
+front, preserving the caller's precedence order.
+
 ## 1.7.1
 
 ### Apple: sign the inner frameworks too, not just the outer xcframework

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 
-project(dart_bridge VERSION 1.7.1 LANGUAGES C)
+project(dart_bridge VERSION 1.8.0 LANGUAGES C)
 
 if(NOT DEFINED DART_BRIDGE_PYTHON_INCLUDE_DIRS)
   find_package(Python3 REQUIRED COMPONENTS Development.Module)

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -359,11 +359,11 @@ static const char* SP_MODULE_PATHS_EPILOGUE =
 static int sp_apply_module_paths(sp_state_t* st) {
     if (st->module_paths_count == 0) return 0;
 
-    // Build "_sp_paths = [...]" followed by the epilogue.
-    // Conservative buffer estimate: per-entry ~3x worst-case escaping.
+    // Conservative buffer estimate: escaping can emit up to 8 output bytes
+    // per input byte, plus per-entry quoting/separator overhead.
     size_t total = 64 + strlen(SP_MODULE_PATHS_EPILOGUE);
     for (size_t i = 0; i < st->module_paths_count; i++) {
-        total += strlen(st->module_paths[i]) * 3 + 8;
+        total += strlen(st->module_paths[i]) * 8 + 8;
     }
     char* code = (char*)malloc(total);
     if (!code) return -1;
@@ -373,13 +373,12 @@ static int sp_apply_module_paths(sp_state_t* st) {
     p += n;
 
     for (size_t i = 0; i < st->module_paths_count; i++) {
-        // Quote with repr-safe escaping: replace backslash and apostrophe.
-        // Simpler approach: use Python triple-quoted raw string? No — use
-        // explicit escaping.
+        // Quote with raw-string fragments, splitting around apostrophes.
         n = snprintf(p, total - (p - code), "%sr'", i == 0 ? "" : ", ");
         p += n;
         const char* src = st->module_paths[i];
-        for (; *src && (size_t)(p - code) < total - 4; src++) {
+        // Defensive bound only — unreachable with the 8x sizing above.
+        for (; *src && (size_t)(p - code) < total - 12; src++) {
             if (*src == '\'') {
                 // r-strings can't contain unescaped quotes that match;
                 // fall back to concatenation.

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -333,30 +333,13 @@ static int sp_apply_inittab(void) {
     return 0;
 }
 
-// Python source appended after the generated `_sp_paths = [...]` list literal
-// in sp_apply_module_paths. Three jobs:
-//
-// 1. Dedupe. The platform plugins pass the same list both as PYTHONPATH
-//    (env, consumed by Py_Initialize) and as module_paths, so each entry
-//    would otherwise appear on sys.path twice. Drop any existing occurrence
-//    (compared case-/separator-insensitively — on Windows PYTHONPATH entries
-//    can come back with different casing) and re-insert the list at the front,
-//    preserving the caller's highest-to-lowest precedence order.
-//
-// 2. Treat every module path as a *site directory*. CPython only processes
-//    `.pth` files for site dirs (PYTHONHOME's own Lib/site-packages) — never
-//    for PYTHONPATH entries — so packages that rely on a `.pth` to extend
-//    sys.path or run bootstrap code were broken in the bundled site-packages.
-//    pywin32 is the canonical case: `pywin32.pth` adds `win32`, `win32\lib`
-//    and `pythonwin` to sys.path and imports `pywin32_bootstrap`, which
-//    registers `pywin32_system32` as a DLL directory; without it
-//    `import win32com` fails with "No module named 'pywintypes'"
-//    (flet-dev/flet#5071). `site.addsitedir` appends `.pth` path lines after
-//    the existing entries, exactly as a normal installation would, and skips
-//    paths that are not directories (Android zips, missing `__pypackages__`).
-//
-// 3. Clean up the temporaries from `__main__`'s globals, which this code runs
-//    in (see sp_pyrun_string).
+// Python source appended to the generated `_sp_paths = [...]` literal.
+// Plugins also pass these paths through PYTHONPATH, so drop the existing
+// occurrences before re-inserting the list at the front in the configured order.
+// Register each directory with site.addsitedir() so its `.pth` files are processed
+// — CPython never does this for PYTHONPATH entries; non-directories (such
+// as Android zips) stay on sys.path unchanged. Runs in __main__'s globals,
+// which the user's program shares — hence the final `del`.
 static const char* SP_MODULE_PATHS_EPILOGUE =
     "\n"
     "import os, site\n"
@@ -369,10 +352,10 @@ static const char* SP_MODULE_PATHS_EPILOGUE =
     "        site.addsitedir(_p)\n"
     "del _sp_paths, _sp_norm, _p, os, site\n";
 
-// Insert module_paths into sys.path after Py_Initialize and register them as
-// site directories (see SP_MODULE_PATHS_EPILOGUE). Uses sp_pyrun_string
-// because PyConfig.module_search_paths isn't in the Limited API as of
-// Python 3.12.
+// Put module_paths on sys.path and register them as site directories, by
+// generating the `_sp_paths = [...]` literal and evaluating it together with
+// SP_MODULE_PATHS_EPILOGUE. Done as Python source after Py_Initialize because
+// the Limited API has no PyConfig.module_search_paths (as of Python 3.12).
 static int sp_apply_module_paths(sp_state_t* st) {
     if (st->module_paths_count == 0) return 0;
 

--- a/src/serious_python_run.c
+++ b/src/serious_python_run.c
@@ -333,15 +333,52 @@ static int sp_apply_inittab(void) {
     return 0;
 }
 
-// Insert module_paths into sys.path AFTER Py_Initialize. Uses
-// PyRun_SimpleString because PyConfig.module_search_paths isn't in the
-// Limited API as of Python 3.12.
+// Python source appended after the generated `_sp_paths = [...]` list literal
+// in sp_apply_module_paths. Three jobs:
+//
+// 1. Dedupe. The platform plugins pass the same list both as PYTHONPATH
+//    (env, consumed by Py_Initialize) and as module_paths, so each entry
+//    would otherwise appear on sys.path twice. Drop any existing occurrence
+//    (compared case-/separator-insensitively — on Windows PYTHONPATH entries
+//    can come back with different casing) and re-insert the list at the front,
+//    preserving the caller's highest-to-lowest precedence order.
+//
+// 2. Treat every module path as a *site directory*. CPython only processes
+//    `.pth` files for site dirs (PYTHONHOME's own Lib/site-packages) — never
+//    for PYTHONPATH entries — so packages that rely on a `.pth` to extend
+//    sys.path or run bootstrap code were broken in the bundled site-packages.
+//    pywin32 is the canonical case: `pywin32.pth` adds `win32`, `win32\lib`
+//    and `pythonwin` to sys.path and imports `pywin32_bootstrap`, which
+//    registers `pywin32_system32` as a DLL directory; without it
+//    `import win32com` fails with "No module named 'pywintypes'"
+//    (flet-dev/flet#5071). `site.addsitedir` appends `.pth` path lines after
+//    the existing entries, exactly as a normal installation would, and skips
+//    paths that are not directories (Android zips, missing `__pypackages__`).
+//
+// 3. Clean up the temporaries from `__main__`'s globals, which this code runs
+//    in (see sp_pyrun_string).
+static const char* SP_MODULE_PATHS_EPILOGUE =
+    "\n"
+    "import os, site\n"
+    "_sp_norm = {os.path.normcase(os.path.abspath(_p)) for _p in _sp_paths}\n"
+    "sys.path[:] = [_p for _p in sys.path\n"
+    "               if os.path.normcase(os.path.abspath(_p)) not in _sp_norm]\n"
+    "sys.path[:0] = _sp_paths\n"
+    "for _p in _sp_paths:\n"
+    "    if os.path.isdir(_p):\n"
+    "        site.addsitedir(_p)\n"
+    "del _sp_paths, _sp_norm, _p, os, site\n";
+
+// Insert module_paths into sys.path after Py_Initialize and register them as
+// site directories (see SP_MODULE_PATHS_EPILOGUE). Uses sp_pyrun_string
+// because PyConfig.module_search_paths isn't in the Limited API as of
+// Python 3.12.
 static int sp_apply_module_paths(sp_state_t* st) {
     if (st->module_paths_count == 0) return 0;
 
-    // Build "sys.path[:0] = [...]" — insert all entries at the front in order.
+    // Build "_sp_paths = [...]" followed by the epilogue.
     // Conservative buffer estimate: per-entry ~3x worst-case escaping.
-    size_t total = 64;
+    size_t total = 64 + strlen(SP_MODULE_PATHS_EPILOGUE);
     for (size_t i = 0; i < st->module_paths_count; i++) {
         total += strlen(st->module_paths[i]) * 3 + 8;
     }
@@ -349,7 +386,7 @@ static int sp_apply_module_paths(sp_state_t* st) {
     if (!code) return -1;
 
     char* p = code;
-    int n = snprintf(p, total, "import sys\nsys.path[:0] = [");
+    int n = snprintf(p, total, "import sys\n_sp_paths = [");
     p += n;
 
     for (size_t i = 0; i < st->module_paths_count; i++) {
@@ -373,6 +410,7 @@ static int sp_apply_module_paths(sp_state_t* st) {
     }
     *p++ = ']';
     *p   = '\0';
+    snprintf(p, total - (size_t)(p - code), "%s", SP_MODULE_PATHS_EPILOGUE);
 
     int rc = sp_pyrun_string(code, "<sp_module_paths>");
     free(code);


### PR DESCRIPTION
Fixes flet-dev/flet#5071
Fixes flet-dev/flet#4737

## Problem

CPython processes `.pth` files only for *site directories* (`site.py` over `PYTHONHOME`'s `Lib/site-packages`) — never for `PYTHONPATH` entries. Every `serious_python_*` plugin exposes the app's bundled `site-packages` through `PYTHONPATH` / `module_paths` only, so any package that relies on a `.pth` file to extend `sys.path` or run bootstrap code silently broke in packaged apps.

pywin32 is the canonical case. Its layout only works through `pywin32.pth`, which adds `win32`, `win32\lib` and `pythonwin` to `sys.path` and imports `pywin32_bootstrap` — which in turn registers `pywin32_system32` as a DLL directory so the `.pyd` extensions can resolve `pywintypes3xx.dll`. With the `.pth` unprocessed, `import win32com` in a `flet build windows` app fails with `ModuleNotFoundError: No module named 'pywintypes'`.

## Fix

`sp_apply_module_paths` now emits the module-path list into a temporary and runs a fixed epilogue (`SP_MODULE_PATHS_EPILOGUE`) that:

1. **Dedupes `sys.path`:** The plugins pass the same list both as `PYTHONPATH` (consumed by `Py_Initialize`) and as `module_paths` (inserted post-init), so every entry appeared twice. Existing occurrences are removed — compared case-/separator-insensitively via `os.path.normcase(os.path.abspath(...))` — and the list is re-inserted at the front, preserving the caller's precedence order.
2. **Registers every module path that is a directory with `site.addsitedir()`** — the same function `site.py` uses for real site dirs: `.pth` path lines are appended after the existing entries exactly as in a regular installation; `import` lines execute. Non-directories (Android's stdlib/site-packages zips, an absent `__pypackages__`) are skipped.
3. Cleans its temporaries out of `__main__`'s globals, which this snippet shares with the user's program.

A malformed `.pth` is not fatal: `site` prints its usual "Error processing line …" warning and continues, matching stock CPython behavior.

## Also: buffer sizing for the apostrophe escape (`24f4d76`)

While touching `sp_apply_module_paths`, a pre-existing (since 1.5.0) flaw in its buffer math was corrected. The estimate for the generated `_sp_paths` literal budgeted ~3 output bytes per input char, but the apostrophe escape (close the raw string, concatenate `"'"`, reopen) emits 8. An apostrophe-dense path could exhaust the buffer, and the copy guard both reserved too little for its own write (4 bytes vs the escape's 8) and truncated the path silently — after which `total - (p - code)` underflowed as `size_t`, handing the epilogue `snprintf` an effectively unbounded size (heap overflow). Only reachable with pathological paths (a single apostrophe, e.g. `C:\Users\O'Brien\…`, stays well within budget), but it was wrong.

The buffer is now sized for the true worst case (8 bytes per input char), which makes the guard unreachable; it is kept as a defensive bound with a margin covering its largest write. Validated with a byte-accurate replica of the generator (including `snprintf`'s would-be-length advancement) driven with adversarial inputs — 500-apostrophe paths, dense mixes — plus round-trip `compile()`/`exec` of every generated program: no overflow, guard never reached, paths reproduce exactly.

## Verification

Reproduced and verified on a Windows 11 VM against Flet v0.86.5:
<details><summary>**Test Code**</summary>
<p>

```python
import traceback

import flet as ft


def main(page: ft.Page):
    page.scroll = ft.ScrollMode.AUTO
    try:
        import win32com.client

        shell = win32com.client.Dispatch("WScript.Shell")
        result = ft.Text(
            f"win32com OK — WScript.Shell dispatched: {shell}",
            color=ft.Colors.GREEN,
        )
    except Exception:
        result = ft.Text(traceback.format_exc(), color=ft.Colors.RED)

    import sys

    page.add(
        result,
        ft.Text("sys.path:"),
        *[ft.Text(p, size=12) for p in sys.path],
    )


ft.run(main)
``` 

```toml
[project]
name = "issue-5071"
version = "0.1.0"
description = "Repro for flet-dev/flet#5071 - pywin32 (win32com) in built Windows app"
requires-python = ">=3.10"
dependencies = [
    "flet",
    "pywin32; sys_platform == 'win32'",
]

[tool.flet]
org = "com.mycompany"
product = "issue-5071"
``` 
</p>
</details> 

- **Before**: `import win32com.client` → `No module named 'pywintypes'`; every `sys.path` entry listed twice.

<img width="893" height="587" alt="image" src="https://github.com/user-attachments/assets/5f110e4e-cde8-4034-a95b-8c7d80ac3a80" />


- **After** (CI-built DLL dropped over `dart_bridge.dll` in the built app): `win32com.client.Dispatch("WScript.Shell")` succeeds; `sys.path` entries appear once, with `win32`, `win32\lib`, `pythonwin` appended at the end.

<img width="647" height="444" alt="image" src="https://github.com/user-attachments/assets/4649189f-1343-4838-b640-5dae04c56db2" />